### PR TITLE
Add posix_spawn for ninja

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,13 @@ Makefile
 install_manifest.txt
 lib/
 *.cmake
+*.dbg
+*.log
+*.pax.Z
+config.success
+test.status
+test/cctest
+test/cctest_a
 
 # Build artifacts
 *.a

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,6 @@ if(${CMAKE_C_COMPILER} MATCHES ibm-clang64)
   list(APPEND zoslib_cflags
     -fgnu-keywords
     -march=arch10
-    -mtune=arch10
     -fno-short-enums
     -fzos-le-char-mode=ascii)
 else()

--- a/include/spawn.h
+++ b/include/spawn.h
@@ -1,0 +1,58 @@
+///////////////////////////////////////////////////////////////////////////////
+////// Licensed Materials - Property of IBM
+////// ZOSLIB
+////// (C) Copyright IBM Corp. 2022. All Rights Reserved.
+////// US Government Users Restricted Rights - Use, duplication
+////// or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+///////////////////////////////////////////////////////////////////////////////////
+
+#ifndef _ZOS_SPAWN_H
+#define _ZOS_SPAWN_H
+
+#include_next <spawn.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define POSIX_SPAWN_SETPGROUP 0x02
+#define POSIX_SPAWN_SETSIGMASK 0x08
+#define POSIX_SPAWN_USEVFORK 0x40
+#define POSIX_SPAWN_SETSIGDEF 0x01
+#define POSIX_SPAWN_SETSCHEDPARAM 0x04
+#define POSIX_SPAWN_SETSCHEDULER 0x10
+#define POSIX_SPAWN_RESETIDS 0x20
+
+typedef struct posix_spawn_file_actions_t {
+  struct _spawn_actions *actions;
+} posix_spawn_file_actions_t;
+
+typedef struct posix_spawnattr_t {
+  sigset_t *mask;
+  short flags;
+} posix_spawnattr_t;
+
+int posix_spawn_file_actions_init(posix_spawn_file_actions_t *);
+int posix_spawn_file_actions_addclose(posix_spawn_file_actions_t *,
+                                      int pipe_fd);
+int posix_spawn_file_actions_addopen(posix_spawn_file_actions_t *, int,
+                                     const char *, int flags, mode_t);
+int posix_spawn_file_actions_adddup2(posix_spawn_file_actions_t *, int pipe_fd,
+                                     int fd);
+int posix_spawn_file_actions_destroy(posix_spawn_file_actions_t *);
+
+int posix_spawnattr_init(posix_spawnattr_t *);
+int posix_spawnattr_setsigmask(posix_spawnattr_t *, sigset_t *mask);
+int posix_spawnattr_setflags(posix_spawnattr_t *, short flags);
+int posix_spawnattr_destroy(posix_spawnattr_t *);
+
+int posix_spawn(pid_t *pid, const char *cmd,
+                const posix_spawn_file_actions_t *act,
+                const posix_spawnattr_t *, char *const args[],
+                char *const env[]);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/string.h
+++ b/include/string.h
@@ -1,0 +1,29 @@
+///////////////////////////////////////////////////////////////////////////////
+//// Licensed Materials - Property of IBM
+//// ZOSLIB
+//// (C) Copyright IBM Corp. 2022. All Rights Reserved.
+//// US Government Users Restricted Rights - Use, duplication
+//// or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+/////////////////////////////////////////////////////////////////////////////////
+//
+#ifndef _ZOS_STRING_H
+#define _ZOS_STRING_H
+
+#include_next <string.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+size_t strnlen(const char *, size_t );
+char *strpcpy(char *, const char *);
+
+const char *strsignal(int );
+const char *sigdescr_np(int);
+const char *sigabbrev_np(int);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/sys/stat.h
+++ b/include/sys/stat.h
@@ -1,0 +1,20 @@
+///////////////////////////////////////////////////////////////////////////////
+////// Licensed Materials - Property of IBM
+////// ZOSLIB
+////// (C) Copyright IBM Corp. 2022. All Rights Reserved.
+////// US Government Users Restricted Rights - Use, duplication
+////// or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+///////////////////////////////////////////////////////////////////////////////////
+
+#ifndef _ZOS_STAT_H
+#define _ZOS_STAT_H
+
+#include_next <sys/stat.h>
+
+#ifndef S_TYPEISMQ  
+#define S_TYPEISMQ  (__x)   (0) /* Test for a message queue */
+#define S_TYPEISSEM(__x)    (0) /* Test for a semaphore     */
+#define S_TYPEISSHM(__x)    (0) /* Test for a shared memory */
+#endif
+
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,8 @@
 ###############################################################################
 
 set(libsrc
+  string.c
+  spawn-zos.cc
   zos-bpx.cc
   zos-char-util.cc
   zos-getentropy.cc

--- a/src/spawn-zos.cc
+++ b/src/spawn-zos.cc
@@ -1,0 +1,233 @@
+///////////////////////////////////////////////////////////////////////////////
+//// Licensed Materials - Property of IBM
+//// ZOSLIB
+//// (C) Copyright IBM Corp. 2022. All Rights Reserved.
+//// US Government Users Restricted Rights - Use, duplication
+//// or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+/////////////////////////////////////////////////////////////////////////////////
+
+#include <spawn.h>
+#include <stdlib.h>
+#include <signal.h>
+#include <errno.h>
+#include <stdio.h>
+#include <fcntl.h>
+#define _POSIX_SOURCE
+#include <unistd.h>
+
+enum ActionKinds { op_open, op_close, op_dup2};
+struct _spawn_actions {
+  ActionKinds op;
+  int fd;
+  struct Open_info {
+    const char *path;
+    int oflags;
+    mode_t mode;
+  } open_info;
+  int new_fd;
+  _spawn_actions * next;
+};
+
+
+// -----------  Actions
+
+int posix_spawn_file_actions_init(posix_spawn_file_actions_t* act) {
+	if (act==nullptr)
+		return EINVAL;
+	act->actions = nullptr;
+  return 0;
+}
+
+void printActions(const posix_spawn_file_actions_t* act) {
+  fprintf(stderr, "posix)spawn_file_actions_t:%p:", act);
+  for (const _spawn_actions *p = act->actions; p ; p = p->next) {
+    switch (p->op) {
+    case op_open:
+      fprintf(stderr, "open-%p(%d,%s,%08x,%08x):", p, p->fd, p->open_info.path, p->open_info.oflags, p->open_info.mode);
+      break;
+    case op_close:
+      fprintf(stderr, "close-%p(%d):", p, p->fd);
+      break;
+    case op_dup2:
+      fprintf(stderr, "dup2-%p(%d,%d):", p, p->fd, p->new_fd);
+      break;
+    default:
+      fprintf(stderr, "unkown-%p(%d):", p, p->op);
+      break;
+    }
+  }
+  fprintf(stderr, "\n");
+}
+
+static _spawn_actions* appendAction(posix_spawn_file_actions_t* act) {
+	_spawn_actions * tail = act->actions;
+	_spawn_actions * p = (_spawn_actions*) malloc(sizeof(_spawn_actions));
+	if (p==nullptr) {
+		return nullptr;
+	}
+	p->next = nullptr;
+	if (tail==nullptr) {
+		act->actions = p;
+	} else {
+		for (; tail->next; tail=tail->next) {
+		}
+		tail->next = p;
+	}
+	return p;
+}
+
+int posix_spawn_file_actions_addclose(posix_spawn_file_actions_t* act, int pipe_fd) {
+	if (act==nullptr)
+		return EINVAL;
+  if (pipe_fd<0 || pipe_fd>sysconf(_SC_OPEN_MAX))
+    return EBADF;
+
+	_spawn_actions * p = appendAction(act);
+	if (!p)
+		return ENOMEM;
+	p->op = op_close;
+	p->fd = pipe_fd;
+
+	return 0;
+	
+}
+
+int posix_spawn_file_actions_addopen(posix_spawn_file_actions_t* act, int pipe_fd, const char *path, int flags, mode_t mode) {
+	if (act==nullptr)
+		return EINVAL;
+  if (pipe_fd<0 || pipe_fd>sysconf(_SC_OPEN_MAX))
+    return EBADF;
+
+	_spawn_actions * p = appendAction(act);
+	if (!p)
+		return ENOMEM;
+  p->op = op_open;
+	p->fd = pipe_fd;
+  p->open_info.path = path;	
+  p->open_info.oflags = flags;	
+  p->open_info.mode = mode;	
+  return 0;
+}
+
+int posix_spawn_file_actions_adddup2(posix_spawn_file_actions_t* act, int pipe_fd, int nfd) {
+	if (act==nullptr)
+		return EINVAL;
+  if (pipe_fd<0 || pipe_fd>sysconf(_SC_OPEN_MAX))
+    return EBADF;
+  if (nfd<0 || nfd>sysconf(_SC_OPEN_MAX))
+    return EBADF;
+	_spawn_actions * p = appendAction(act);
+	if (!p)
+		return ENOMEM;
+  p->op = op_dup2;
+	p->fd = pipe_fd;
+	p->new_fd = nfd;
+	return 0;
+}
+
+int posix_spawn_file_actions_destroy(posix_spawn_file_actions_t* act) {
+	if (act==nullptr)
+		return EINVAL;
+
+	_spawn_actions *cur = act->actions;
+	for (; cur;) {
+		_spawn_actions *next = cur->next;
+		free(cur);
+		cur=next;
+	}
+	return 0;
+}
+
+// --------------  Attributes
+int posix_spawnattr_init(posix_spawnattr_t* attr){
+	if (attr==nullptr)
+		return EINVAL;
+	attr->flags = 0;
+	attr->mask = 0;
+	return 0;
+}
+
+int posix_spawnattr_setsigmask(posix_spawnattr_t* attr, sigset_t *mask){
+	if (attr==nullptr)
+		return EINVAL;
+	attr->mask = mask;
+	return 0;
+}
+
+
+int posix_spawnattr_setflags(posix_spawnattr_t* attr, short flags) {
+	if (attr==nullptr)
+		return EINVAL;
+
+  attr->flags = flags;
+  return 0;
+}
+
+int posix_spawnattr_destroy(posix_spawnattr_t* attr) {
+	if (attr==nullptr)
+		return EINVAL;
+  return 0;
+}
+
+int posix_spawn(pid_t *pid, const char *cmd, const posix_spawn_file_actions_t *act, const posix_spawnattr_t* attr, char * const args[], char * const env[]) {
+
+	if (pid==nullptr)
+		return EINVAL;
+#if HAS_VFORK
+  const short flags_with_actions = POSIX_SPAWN_SETSIGMASK|POSIX_SPAWN_SETSIGDEF|
+          POSIX_SPAWN_SETSCHEDPARAM|POSIX_SPAWN_SETSCHEDULER|
+          POSIX_SPAWN_SETPGROUP|POSIX_SPAWN_RESETIDS;
+  if ((attr->flags & POSIX_SPAWN_USEVFORK) ||
+  	  (act->actions==nullptr && !(attr->flags&flags_with_actions)))
+  {
+  	// Simple fork() with no clean up actions
+  	*pid = vfork();
+  } else
+#endif
+  {
+  	*pid = fork();
+  }
+
+  if (*pid < 0)
+    return 1;
+
+  if (*pid == 0) {
+  	// In the child
+    int rc = 0;
+  	if (attr->flags & POSIX_SPAWN_SETSIGMASK) {
+      if ((rc=sigprocmask(SIG_SETMASK, attr->mask, 0)) < 0)
+        return rc;  		
+  	}
+
+    if (attr->flags & POSIX_SPAWN_SETPGROUP) {
+      if ((rc=setpgid(0, 0)) < 0)
+        return rc;
+    }
+  	
+  	_spawn_actions *cur = act->actions;
+  	for (; cur; cur=cur->next) {
+  		switch (cur->op) {
+  			case op_close: close(cur->fd); break;
+  		  case op_open: {
+  		  	int fd = open(cur->open_info.path, cur->open_info.oflags, cur->open_info.mode);
+  		  	if (fd < 0)
+  		  		return fd;
+  		  	if (fd != cur->fd) {
+  		  		if ((rc=dup2(fd, cur->fd)) < 0)
+  		  			return rc;
+    		  	close(fd);
+  		  	}
+  		    break;
+  		  }
+  		  case op_dup2:
+  		  	if ((rc=dup2(cur->fd, cur->new_fd)) < 0)
+  		  		return rc;
+          break;
+  			default: return 127;
+  		}
+  	}
+  execve(cmd, args, env);
+  return 127;
+  }
+  return 0;
+}

--- a/src/string.c
+++ b/src/string.c
@@ -1,0 +1,127 @@
+/////////////////////////////////////////////////////////////////////////////////
+//// Licensed Materials - Property of IBM
+//// ZOSLIB
+//// (C) Copyright IBM Corp. 2022. All Rights Reserved.
+//// US Government Users Restricted Rights - Use, duplication
+//// or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+/////////////////////////////////////////////////////////////////////////////////
+
+#define _AE_BIMODAL 1
+
+#include <string.h>
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <_Nascii.h>
+
+#define SignalList \
+  SigInfo(0,     "Signal 0"), \
+  SigInfo(HUP,   "SIGHUP"), \
+  SigInfo(INT,   "SIGINT"), \
+  SigInfo(ABRT,  "SIGABRT"), \
+  SigInfo(ILL,   "SIGILL"), \
+  SigInfo(5,     "Signal 5"), \
+  SigInfo(6,     "Signal 6"), \
+  SigInfo(STOP,  "SIGSTOP"), \
+  SigInfo(FPE,   "SIGFPE"), \
+  SigInfo(KILL,  "SIGKILL"), \
+  SigInfo(10,    "Signal 10"), \
+  SigInfo(SEGV,  "SIGSEGV"), \
+  SigInfo(12,    "Signal 12"), \
+  SigInfo(PIPE,  "SIGPIPE"), \
+  SigInfo(ALRM,  "SIGALRM"), \
+  SigInfo(TERM,  "SIGTERM"), \
+  SigInfo(USR1,  "SIGUSR1"), \
+  SigInfo(USR2,  "SIGUSR2"), \
+  SigInfo(ABND,  "SIGABND"), \
+  SigInfo(CONT,  "SIGCONT"), \
+  SigInfo(CHLD,  "SIGCHLD"), \
+  SigInfo(TTIN,  "SIGTTIN"), \
+  SigInfo(TTOU,  "SIGTTOU"), \
+  SigInfo(IO,    "SIGIO"), \
+  SigInfo(QUIT,  "SIGQUIT"), \
+  SigInfo(TSTP,  "SIGTSTP"), \
+  SigInfo(TRAP,  "SIGTRAP"), \
+  SigInfo(IOERR, "SIGIOERR"), \
+  SigInfo(28, "Signal 28"), \
+  SigInfo(29, "Signal 29"), \
+  SigInfo(30, "Signal 30"), \
+  SigInfo(31, "Signal 31"), \
+  SigInfo(32, "Signal 32"), \
+  SigInfo(33, "Signal 33"), \
+  SigInfo(34, "Signal 34"), \
+  SigInfo(35, "Signal 35"), \
+  SigInfo(36, "Signal 36"), \
+  SigInfo(37, "Signal 37"), \
+  SigInfo(DCE, "SIGDCE"), \
+  SigInfo(DUMP, "SIGDUMP")
+
+#define SigInfo(N, D) sig##N
+enum Sigs {
+  SignalList,
+  sigTotal
+};
+#undef SigInfo
+
+#define SigInfo(N, D) D
+#pragma convert("IBM-1047")
+static const char *signalTextEBCDIC[] = {
+  SignalList
+};
+#pragma convert(pop)
+#pragma convert("ISO8859-1")
+static const char *signalTextASCII[] = {
+  SignalList
+};
+#pragma convert(pop)
+#undef SigInfo
+
+#define SigInfo(N, D) #N
+#pragma convert("IBM-1047")
+static const char *signalAbbrevEBCDIC[] = {
+  SignalList
+};
+#pragma convert(pop)
+#pragma convert("ISO8859-1")
+static const char *signalAbbrevASCII[] = {
+  SignalList
+};
+#pragma convert(pop)
+#undef SigInfo
+
+#define lookup(arr, n) (__isASCII()? arr##ASCII[n] : arr##EBCDIC[n])
+
+const char *strsignal(int signum) {
+  if (signum < sigTotal)
+    return lookup(signalText,signum);
+  errno=EDOM;
+  return NULL;
+}
+
+const char *sigdescr_np(int signum) {
+  return strsignal(signum);
+}
+
+const char *sigabbrev_np(int signum) {
+  if (signum < sigTotal)
+    return lookup(signalAbbrev,signum);
+  errno=EDOM;
+  return NULL;
+}
+
+size_t strnlen(const char *s, size_t maxlen) {
+  const char *ptr = (const char *)memchr(s, '\0', maxlen);
+  return ptr ? ptr - s : maxlen;
+}
+
+char *strpcpy(char *dest, const char *src) {
+  char *ptr = strcpy(dest, src);
+  return ptr + strlen(ptr);
+}
+
+#if TEST
+int main() {
+  printf("values: segv=%d total=%d\n", SIGSEGV, sigTotal);
+  printf("signal segv: abbrev='%s' str='%s'\n", sigabbrev_np(SIGSEGV), strsignal(SIGSEGV));
+}
+#endif


### PR DESCRIPTION
I added all of the wrappers I had in a separate library to enhance POSIX support.  Some of these are used in ninja so I added them all.

The list is:
- string.h
  - strnlen
  - strpcpy
  - strsignal
  - sigdescr_np
  - sigabbrev_np
- spawn.h
  - posix_spawn & support functions
- sys/stat.h
  - S_TYPEISMQ
  - S_TYPEISSEM
  - S_TYPEISSHM
 
The implementation of posix_spawn() is really basic.  It uses fork/exec.  It seems to be fully functional.