### PR TITLE
extended realpath

### DIFF
--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -15,6 +15,7 @@
 #if defined(__cplusplus)
 extern "C" {
 #endif
+__Z_EXPORT extern char *__realpath_extended(const char * __restrict__, char * __restrict__);
 __Z_EXPORT int __mkstemp_ascii(char*);
 #if defined(__cplusplus)
 };
@@ -22,15 +23,22 @@ __Z_EXPORT int __mkstemp_ascii(char*);
 
 #if defined(ZOSLIB_OVERRIDE_CLIB) || defined(ZOSLIB_OVERRIDE_CLIB_STDLIB)
 
+#undef realpath
+#define realpath __realpath_replaced
 #undef mkstemp
 #define mkstemp __mkstemp_replaced
 #include_next <stdlib.h>
-#undef mkstemp 
+#undef mkstemp
+#undef realpath
 
 #if defined(__cplusplus)
 extern "C" {
 #endif
 
+/**
+ * Same as original realpath, but this allocates a buffer if second parm is NULL as defined in Posix.1-2008
+ */
+__Z_EXPORT extern char *realpath(const char * __restrict__, char * __restrict__) asm("__realpath_extended");
 /**
  * Same as C mkstemp but tags fd as ASCII (819)
  */

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -15,7 +15,7 @@
 #if defined(__cplusplus)
 extern "C" {
 #endif
-__Z_EXPORT extern char *__realpath_extended(const char * __restrict__, char * __restrict__);
+__Z_EXPORT char *__realpath_extended(const char * __restrict__, char * __restrict__);
 __Z_EXPORT int __mkstemp_ascii(char*);
 #if defined(__cplusplus)
 };
@@ -38,7 +38,7 @@ extern "C" {
 /**
  * Same as original realpath, but this allocates a buffer if second parm is NULL as defined in Posix.1-2008
  */
-__Z_EXPORT extern char *realpath(const char * __restrict__, char * __restrict__) asm("__realpath_extended");
+__Z_EXPORT char *realpath(const char * __restrict__, char * __restrict__) asm("__realpath_extended");
 /**
  * Same as C mkstemp but tags fd as ASCII (819)
  */

--- a/src/zos-bpx.cc
+++ b/src/zos-bpx.cc
@@ -56,7 +56,7 @@ char *__realpath(const char *path, char *resolved_path) {
    strcpy(ebcdic_path, path);
    __a2e_s(ebcdic_path);
    path_len = strlen(path);
-   if (resolved_path == NULL){
+   if (resolved_path == NULL) {
       resolved_path = (char*) malloc(pathmax_size(path) + 1);
    }
    path_resolved_len=strlen(resolved_path);
@@ -84,8 +84,8 @@ char *__realpath(const char *path, char *resolved_path) {
 
 char *__realpath_orig(const char __restrict__ *path, char __restrict__ *resolved_path) asm("@@A00187");
 
-char *__realpath_extended(const char __restrict__ *path, char __restrict__ *resolved_path){
-   if (resolved_path == NULL){
+char *__realpath_extended(const char __restrict__ *path, char __restrict__ *resolved_path) {
+   if (resolved_path == NULL) {
       resolved_path = (char*) malloc(pathmax_size(path) + 1);
    }
    return __realpath_orig(path, resolved_path);

--- a/src/zos-bpx.cc
+++ b/src/zos-bpx.cc
@@ -7,13 +7,14 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "zos-bpx.h"
+#include "zos-base.h"
 
 #define _POSIX_SOURCE
 #include <assert.h>
 #include <errno.h>
 #include <string.h>
 #include <unistd.h>
-
+#include <stdlib.h>
 #include <mutex>
 
 #ifdef __cplusplus
@@ -33,6 +34,63 @@ char *__ptr32 *__ptr32 __uss_base_address(void) {
   }
   return res;
 }
+
+static ssize_t pathmax_size(const char* path) {
+  ssize_t pathmax;
+
+  pathmax = pathconf(path, _PC_PATH_MAX);
+
+  if (pathmax == -1)
+    pathmax = PATH_MAX;
+
+  return pathmax;
+}
+
+#if TRACE_ON // for debugging use
+
+char *__realpath(const char *path, char *resolved_path) asm("@@A00187");
+char *__realpath(const char *path, char *resolved_path) {
+   void *reg15 = __uss_base_address()[884 / 4]; // BPX4RPH offset is 884
+   int rv, rc, rn, path_len, path_resolved_len;
+   char *ebcdic_path = (char*) malloc(strlen(path) + 1);
+   strcpy(ebcdic_path, path);
+   __a2e_s(ebcdic_path);
+   path_len = strlen(path);
+   if (resolved_path == NULL){
+      resolved_path = (char*) malloc(pathmax_size(path) + 1);
+   }
+   path_resolved_len=strlen(resolved_path);
+   const void *argv[] = {&path_len, ebcdic_path, &path_resolved_len, resolved_path, &rv, &rc, &rn};
+   __asm volatile(" basr 14,%0\n"
+                  : "+NR:r15"(reg15)
+                  : "NR:r1"(&argv)
+                  : "r0", "r14");
+   free(ebcdic_path);
+   if (-1 == rv) {
+     __console_printf("%s:%s:%d path: %s rval: %d rcode: %d reason: %d\n",
+                       __FILE__, __FUNCTION__, __LINE__, path, rv, rc, rn);
+     errno = rc;
+     return NULL;
+   }
+   __e2a_s(resolved_path);
+   __console_printf("%s:%s:%d path: %s pathresolved: %s length: %d\n",
+                     __FILE__, __FUNCTION__, __LINE__, path, resolved_path, rv);
+   return resolved_path;
+}
+#endif // if TRACE_ON - for debugging use
+
+// C Library Overrides
+//-----------------------------------------------------------------
+
+char *__realpath_orig(const char __restrict__ *path, char __restrict__ *resolved_path) asm("@@A00187");
+
+char *__realpath_extended(const char __restrict__ *path, char __restrict__ *resolved_path){
+   if (resolved_path == NULL){
+      resolved_path = (char*) malloc(pathmax_size(path) + 1);
+   }
+   return __realpath_orig(path, resolved_path);
+}
+
 
 void __bpx4kil(int pid, int signal, void *signal_options, int *return_value,
                int *return_code, int *reason_code) {


### PR DESCRIPTION
This will support specifying a NULL value as a second parameter on a call to realpath, as defined in posix Posix.1-2008, but not yet supported by omvs.