### PR TITLE
Add code to call zoslib_env_hook

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,11 +20,14 @@ set(libsrc
   zos-mount.c
   celquopt.s
 )
+set(zoslib-help zoslib-help.cc)
 
 add_library(libzoslib OBJECT ${libsrc})
 
 add_library(zoslib SHARED $<TARGET_OBJECTS:libzoslib>)
 add_library(zoslib_a STATIC $<TARGET_OBJECTS:libzoslib>)
+add_executable(zoslib-help ${zoslib-help})
+target_link_libraries(zoslib-help libzoslib)
 
 set_target_properties(zoslib_a PROPERTIES OUTPUT_NAME zoslib)
 
@@ -32,6 +35,11 @@ install(
     DIRECTORY ${PROJECT_BINARY_DIR}/lib/
     DESTINATION "lib"
     FILES_MATCHING PATTERN "*")
+
+install(
+    DIRECTORY ${PROJECT_BINARY_DIR}/src/
+    DESTINATION "bin"
+    FILES_MATCHING PATTERN "zoslib-help")
 
 install(
     DIRECTORY ${CMAKE_SOURCE_DIR}/include/

--- a/src/zos.cc
+++ b/src/zos.cc
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
 // Licensed Materials - Property of IBM
-// iOSLIB
+// ZOSLIB
 // (C) Copyright IBM Corp. 2020. All Rights Reserved.
 // US Government Users Restricted Rights - Use, duplication
 // or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
@@ -2724,11 +2724,23 @@ int __zinit::initialize(const zoslib_config_t &aconfig) {
   else {
     setenv("_CEE_RUNOPTS", "FILETAG(AUTOCVT,AUTOTAG) POSIX(ON)", 1);
   }
-  
-  setenv("_BPXK_AUTOCVT", "ON", 1);
-  setenv("_TAG_REDIR_IN", "txt", 1);
-  setenv("_TAG_REDIR_OUT", "txt", 1);
-  setenv("_TAG_REDIR_ERR", "txt", 1);
+
+  tenv = getenv("_BPXK_AUTOCVT");
+  if (!tenv || !*tenv || strcmp("OFF", tenv) == 0) {
+    setenv("_BPXK_AUTOCVT", "ON", 1);
+  }
+
+  tenv = getenv("_TAG_REDIR_IN");
+  if (!tenv || !*tenv)
+    setenv("_TAG_REDIR_IN", "txt", 1);
+
+  tenv = getenv("_TAG_REDIR_OUT");
+  if (!tenv || !*tenv)
+    setenv("_TAG_REDIR_OUT", "txt", 1);
+
+  tenv = getenv("_TAG_REDIR_ERR");
+  if (!tenv || !*tenv)
+    setenv("_TAG_REDIR_ERR", "txt", 1);
 
   std::string ccsid;
   if (get_env_var("__STDIN_CCSID", ccsid))

--- a/src/zos.cc
+++ b/src/zos.cc
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////////
 // Licensed Materials - Property of IBM
-// ZOSLIB
+// iOSLIB
 // (C) Copyright IBM Corp. 2020. All Rights Reserved.
 // US Government Users Restricted Rights - Use, duplication
 // or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
@@ -2674,11 +2674,11 @@ static void setProcessEnvars() {
 
       void* handle = dlopen(0,0);
       if (handle == 0) {
-        perror("Failed to open executable");
-        return 1;
+        perror("Failed to dlopen executable");
+        return;
       }
 
-      zoslib_env_hook_func zoslib_env_hook_ptr = (zoslib_env_hook_func)dlsym(handle, "zopen_env_hook");
+      zoslib_env_hook_func zoslib_env_hook_ptr = (zoslib_env_hook_func)dlsym(handle, "zoslib_env_hook");
       if (zoslib_env_hook_ptr != NULL) {
         zoslib_env_hook_ptr(reinterpret_cast<char*> (&parent[0]));
       }


### PR DESCRIPTION
* sets envars _CEE_RUNOPTS, _BPXK_AUTOCVT, _TAG_REDIR* in case a child process is created, it should propagate them to the child process
* Adds logic to find the process parent directory before main runs
* Adds logic to call zoslib_env_hook

This has been tested with Git:
* Related PR: https://github.com/ZOSOpenTools/meta/pull/236

* Also adds a zoslib-help executable
