### PR TITLE
Add a mkfifo ascii overrides that tags FIFO special files as ASCII

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-*.png   git-encoding=BINARY    zos-working-tree-encoding=BINARY binary
 *	text	working-tree-encoding=ISO8859-1
+*.png   binary

--- a/include/sys/stat.h
+++ b/include/sys/stat.h
@@ -15,7 +15,7 @@
 extern "C" {
 #endif
 /**
- * Same as C open but tags new files as ASCII (819)
+ * Same as C mkfifo but tags FIFO special files as ASCII (819)
  */
 __Z_EXPORT extern int __mkfifo_ascii(const char *pathname, mode_t mode);
 

--- a/include/sys/stat.h
+++ b/include/sys/stat.h
@@ -9,9 +9,47 @@
 #ifndef ZOS_SYS_STAT_H
 #define ZOS_SYS_STAT_H
 
+#include "zos-macros.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+/**
+ * Same as C open but tags new files as ASCII (819)
+ */
+__Z_EXPORT extern int __mkfifo_ascii(const char *pathname, mode_t mode);
+
+#if defined(__cplusplus)
+};
+#endif
+
+#if defined(ZOSLIB_OVERRIDE_CLIB)
+
+#undef mkfifo
+#define mkfifo __mkfifo_replaced
+#include_next <sys/stat.h>
+#undef mkfifo 
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+__Z_EXPORT extern int mkfifo(const char *pathname, mode_t mode) asm("__mkfifo_ascii");
+
+#if defined(__cplusplus)
+};
+#endif
+
+#else // #if !(defined(ZOSLIB_OVERRIDE_CLIB)
+
 #include_next <sys/stat.h>
 
-#ifndef S_TYPEISMQ  
+#endif
+
+#ifdef S_TYPEISMQ  
+#undef S_TYPEISMQ
+#undef S_TYPEISSEM
+#undef S_TYPEISSHM 
 #define S_TYPEISMQ(__x)   (0) /* Test for a message queue */
 #define S_TYPEISSEM(__x)  (0) /* Test for a semaphore     */
 #define S_TYPEISSHM(__x)  (0) /* Test for a shared memory */

--- a/src/zos-io.cc
+++ b/src/zos-io.cc
@@ -659,6 +659,17 @@ int __chgfdccsid(int fd, unsigned short ccsid) {
   return __fchattr(fd, &attr, sizeof(attr));
 }
 
+int __chgpathccsid(char* pathname, unsigned short ccsid) {
+  attrib_t attr;
+  memset(&attr, 0, sizeof(attr));
+  attr.att_filetagchg = 1;
+  attr.att_filetag.ft_ccsid = ccsid;
+  if (ccsid != FT_BINARY) {
+    attr.att_filetag.ft_txtflag = 1;
+  }
+  return __chattr(pathname, &attr, sizeof(attr));
+}
+
 int __setfdccsid(int fd, int t_ccsid) {
   attrib_t attr;
   memset(&attr, 0, sizeof(attr));
@@ -746,6 +757,7 @@ int __close_orig(int) asm("close");
 int __open_orig(const char *filename, int opts, ...) asm("@@A00144");
 int __mkstemp_orig(char *) asm("@@A00184");
 FILE *__fopen_orig(const char *filename, const char *mode) asm("@@A00246");
+int __mkfifo_orig(const char *pathname, mode_t mode) asm("@@A00133");
 
 int __open_ascii(const char *filename, int opts, ...) {
   va_list ap;
@@ -823,6 +835,15 @@ int __pipe_ascii(int fd[2]) {
     return __chgfdccsid(fd[1], 819);
 
   return -1;
+}
+
+int __mkfifo_ascii(const char *pathname, mode_t mode) {
+  int ret = __mkfifo_orig(pathname, mode);
+  if (ret < 0)
+    return ret;
+
+  __chgpathccsid((char*)pathname, 819);
+  return 0; 
 }
 
 int __mkstemp_ascii(char * tmpl) {


### PR DESCRIPTION
This helps https://github.com/ZOSOpenTools/bashport/issues/49