### PR TITLE
Add getutxent and utmpxname ascii overrides

### DIFF
--- a/include/utmpx.h
+++ b/include/utmpx.h
@@ -16,7 +16,7 @@
 extern "C" {
 #endif
 struct utmpx *__getutxent_ascii(void);
-int __utmpxname_ascii(char *);
+__Z_EXPORT int utmpxname(char *);
 
 #if defined(__cplusplus)
 };
@@ -34,7 +34,6 @@ extern "C" {
 #endif
 
 __Z_EXPORT struct utmpx *getutxent(void) asm("__getutxent_ascii");
-__Z_EXPORT int utmpxname(char *) asm("__utmpxname_ascii");
 
 #if defined(__cplusplus)
 };
@@ -42,5 +41,7 @@ __Z_EXPORT int utmpxname(char *) asm("__utmpxname_ascii");
 #else
 #include_next <utmpx.h>
 #endif
+
+#define UTMPX_FILE __UTMPX_FILE
 
 #endif

--- a/include/utmpx.h
+++ b/include/utmpx.h
@@ -1,0 +1,46 @@
+///////////////////////////////////////////////////////////////////////////////
+// Licensed Materials - Property of IBM
+// ZOSLIB
+// (C) Copyright IBM Corp. 2021. All Rights Reserved.
+// US Government Users Restricted Rights - Use, duplication
+// or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef ZOS_UTMPX_H_
+#define ZOS_UTMPX_H_
+
+#define __XPLAT 1
+#include "zos-macros.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+struct utmpx *__getutxent_ascii(void);
+int __utmpxname_ascii(char *);
+
+#if defined(__cplusplus)
+};
+#endif
+
+#if defined(ZOSLIB_OVERRIDE_CLIB) || defined(ZOSLIB_OVERRIDE_CLIB_UTMPX)
+
+#undef getutxent
+#define getutxent __getutxent_replaced
+#include_next <utmpx.h>
+#undef getutxent
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+__Z_EXPORT struct utmpx *getutxent(void) asm("__getutxent_ascii");
+__Z_EXPORT int utmpxname(char *) asm("__utmpxname_ascii");
+
+#if defined(__cplusplus)
+};
+#endif
+#else
+#include_next <utmpx.h>
+#endif
+
+#endif

--- a/src/zos-io.cc
+++ b/src/zos-io.cc
@@ -776,8 +776,8 @@ struct utmpx *__getutxent_ascii(void) {
   if (!utmpx_ptr)
     return utmpx_ptr;
 
-  //TODO: Investigate if it is legal to overwrite the Unix pointer:
-  // Currently converting the string members to ASCII in place.
+  //TODO: Investigate if it is legal to overwrite the data in utmpx struct members:
+  // Currently converting the utmpx string members to ASCII in place.
   __e2a_s(utmpx_ptr->ut_user);
   __e2a_s(utmpx_ptr->ut_id);
   __e2a_s(utmpx_ptr->ut_line);

--- a/src/zos-io.cc
+++ b/src/zos-io.cc
@@ -776,6 +776,8 @@ struct utmpx *__getutxent_ascii(void) {
   if (!utmpx_ptr)
     return utmpx_ptr;
 
+  //TODO: Investigate if it is legal to overwrite the Unix pointer:
+  // Currently converting the string members to ASCII in place.
   __e2a_s(utmpx_ptr->ut_user);
   __e2a_s(utmpx_ptr->ut_id);
   __e2a_s(utmpx_ptr->ut_line);

--- a/src/zos-io.cc
+++ b/src/zos-io.cc
@@ -21,6 +21,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/inotify.h>
+#include <utmpx.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -758,6 +759,29 @@ int __open_orig(const char *filename, int opts, ...) asm("@@A00144");
 int __mkstemp_orig(char *) asm("@@A00184");
 FILE *__fopen_orig(const char *filename, const char *mode) asm("@@A00246");
 int __mkfifo_orig(const char *pathname, mode_t mode) asm("@@A00133");
+struct utmpx *__getutxent_orig(void) asm("getutxent");
+
+int __utmpxname_ascii(char * file) {
+  char buf[PATH_MAX];
+  strncpy(buf, file, strlen(file)+1);
+  buf[sizeof(buf)-1] = '\0';
+  __a2e_s(buf);
+
+  return __utmpxname(buf);
+}
+
+struct utmpx *__getutxent_ascii(void) {
+  utmpx* utmpx_ptr = __getutxent_orig(); 
+  if (!utmpx_ptr)
+    return utmpx_ptr;
+
+  __e2a_s(utmpx_ptr->ut_user);
+  __e2a_s(utmpx_ptr->ut_id);
+  __e2a_s(utmpx_ptr->ut_line);
+  __e2a_s(utmpx_ptr->ut_host);
+
+  return utmpx_ptr;
+}
 
 int __open_ascii(const char *filename, int opts, ...) {
   va_list ap;

--- a/src/zos-io.cc
+++ b/src/zos-io.cc
@@ -761,10 +761,11 @@ FILE *__fopen_orig(const char *filename, const char *mode) asm("@@A00246");
 int __mkfifo_orig(const char *pathname, mode_t mode) asm("@@A00133");
 struct utmpx *__getutxent_orig(void) asm("getutxent");
 
-int __utmpxname_ascii(char * file) {
+int utmpxname(char * file) {
   char buf[PATH_MAX];
-  strncpy(buf, file, strlen(file)+1);
-  buf[sizeof(buf)-1] = '\0';
+  size_t file_len = strnlen(file, PATH_MAX);
+  memcpy(buf, file, file_len);
+  buf[file_len] = '\0';
   __a2e_s(buf);
 
   return __utmpxname(buf);

--- a/src/zos-io.cc
+++ b/src/zos-io.cc
@@ -763,7 +763,7 @@ struct utmpx *__getutxent_orig(void) asm("getutxent");
 
 int utmpxname(char * file) {
   char buf[PATH_MAX];
-  size_t file_len = strnlen(file, PATH_MAX);
+  size_t file_len = strnlen(file, PATH_MAX - 1);
   memcpy(buf, file, file_len);
   buf[file_len] = '\0';
   __a2e_s(buf);


### PR DESCRIPTION
Related to issue https://github.com/ZOSOpenTools/coreutilsport/issues/39.

This affects any tool that reads UTMPX files. Rather than doing the conversion from ebcdic to ascii for each tool, this PR overrides getutxent and exposes utmpxname.