### PR TITLE
Auto-convert the tty file descriptor/stream on fopen/open

### DIFF
--- a/src/zos-io.cc
+++ b/src/zos-io.cc
@@ -814,6 +814,15 @@ int __open_ascii(const char *filename, int opts, ...) {
           errno = old_errno;
         }
       }
+    } else if (isatty(fd)) {
+      // tty devices need to have auto convert enabled
+      struct file_tag *t = &sb.st_tag;
+      if (t->ft_txtflag == 0 && (t->ft_ccsid == 0 || t->ft_ccsid == 1047)) {
+          struct f_cnvrt cvtreq = {SETCVTON, 0, 1047};
+          fcntl(fd, F_CONTROL_CVT, &cvtreq);
+          /* Calling fcntl() should not clobber errno. */
+          errno = old_errno;
+      }
     }
   }
   va_end(ap);
@@ -846,6 +855,15 @@ FILE *__fopen_ascii(const char *filename, const char *mode) {
           // fopen tags untagged files, which enables auto-conversion
           __disableautocvt(fd);
         }
+      }
+    } else if (isatty(fd)) {
+      // tty devices need to have auto convert enabled
+      struct file_tag *t = &sb.st_tag;
+      if (t->ft_txtflag == 0 && (t->ft_ccsid == 0 || t->ft_ccsid == 1047)) {
+          struct f_cnvrt cvtreq = {SETCVTON, 0, 1047};
+          fcntl(fd, F_CONTROL_CVT, &cvtreq);
+          /* Calling fcntl() should not clobber errno. */
+          errno = old_errno;
       }
     }
   }


### PR DESCRIPTION
* This resolves the issue when the /dev/tty* device is opened via fopen or open and then written to or read from. Without this change, we typically see garbled messages printed on the screen. 
* This affects sudo and less (we already have a workaround for less [here](https://github.com/ZOSOpenTools/lessport/pull/3/files#diff-97d7bf57ce9f2f203027bbc46810d35fa50d3a7fe1188a3dd5a3f76e49818ab3R1), but we can undo it with this change)
* I believe it also affects gpg - FYI @HarithaIBM, and potentially others