### PR TITLE
Add sysmacros.h and chdir_long

### DIFF
--- a/include/sys/sysmacros.h
+++ b/include/sys/sysmacros.h
@@ -1,0 +1,16 @@
+///////////////////////////////////////////////////////////////////////////////
+// Licensed Materials - Property of IBM
+// ZOSLIB
+// (C) Copyright IBM Corp. 2021. All Rights Reserved.
+// US Government Users Restricted Rights - Use, duplication
+// or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef ZOS_SYSMACROS_H_
+#define ZOS_SYSMACROS_H_
+
+#define major(x)    (((unsigned)(x) >> 8) & 0x7f)
+#define minor(x)    ((x) & 0xff)
+#define makedev(maj, min) (unsigned short)(((x) << 8) | ((y) & 0xff))
+
+#endif

--- a/include/sys/sysmacros.h
+++ b/include/sys/sysmacros.h
@@ -11,6 +11,6 @@
 
 #define major(x)    (((unsigned)(x) >> 8) & 0x7f)
 #define minor(x)    ((x) & 0xff)
-#define makedev(maj, min) (unsigned short)(((x) << 8) | ((y) & 0xff))
+#define makedev(x, y) (unsigned short)(((x) << 8) | ((y) & 0xff))
 
 #endif

--- a/src/zos.cc
+++ b/src/zos.cc
@@ -3152,6 +3152,11 @@ extern "C" bool __doLogMemoryWarning() {
 
 extern "C" void __mainTerminating() { __gMainTerminating = true; }
 
+//TODO: Implement chdir_long properly, for now call chdir
+extern "C" int chdir_long(char *dir) {
+  return chdir(dir);
+}
+
 #if defined(ZOSLIB_INITIALIZE)
 __init_zoslib __zoslib;
 #endif


### PR DESCRIPTION
* chdir_long is not exposed in a header in Linux, it's just defined - this will help resolve the gnulib issues
* sys/sysmacros.h is used a variety of ports - usually it's guarded for with an alternate implementation but not in the case of procps.