### PR TITLE
Add support for _ENCODE_FILE_NEW + enable man pages

### DIFF
--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -30,4 +30,4 @@ add_custom_command(
 
 
 # Define the install rule for the man page
-#install(FILES "${MAN_OUTPUT_DIR}/${INPUT_FILE}" DESTINATION "${CMAKE_INSTALL_PREFIX}/share/man/man1")
+install(FILES "${CMAKE_SOURCE_DIR}/man/${INPUT_FILE}" DESTINATION "share/man/man1")

--- a/man/zoslib.1
+++ b/man/zoslib.1
@@ -1,4 +1,4 @@
-.TH ZOSLIB 1 "February 2023" "ZOSLIB"
+.TH ZOSLIB 1 "September 2023" "ZOSLIB"
 
 .SH NAME
 zoslib \- a z/OS C/C++ library
@@ -12,16 +12,16 @@ ZOSLIB is a z/OS C/C++ library. It is an extended implementation of the z/OS LE 
 Specify the CCSID for the stdio file descriptors. If these environment variables are not set and if the stdio file descriptor represents an untagged tty, it will be set to 1047 by default.
 
 .TP
-.B __MEMORY_USAGE_LOG_LEVEL
-set to 1 to display only warnings when memory is allocated or freed, and 2 to display all messages; the process started/terminated messages that include memory stats summary, as well as any error messages
+.B _ENCODE_FILE_NEW=ISO8859-1
+(Default) New files are created with encoding ISO8859-1 and tagged ISO8859-1.
 
 .TP
-.B __MEMORY_USAGE_LOG_FILE
-name of the log file associated with __MEMORY_USAGE_LOG_LEVEL, including 'stdout' and 'stderr', to which diagnostic messages for memory allocation and release are to be written
+.B _ENCODE_FILE_NEW=IBM-1047
+New files are created with encoding IBM-1047 and tagged IBM-1047.
 
 .TP
-.B __RUNDEBUG
-set to toggle debug ZOSLIB mode
+.B _ENCODE_FILE_NEW=BINARY
+New files are created without translation and are tagged as BINARY.
 
 .TP
 .B __UNTAGGED_READ_MODE=AUTO
@@ -44,8 +44,16 @@ for no explicit conversion of data
 for same behavior as "AUTO" but issue a warning if conversion occurs
 
 .TP
-.B __IPC_CLEANUP
-set to toggle IPC cleanup at startup
+.B __MEMORY_USAGE_LOG_LEVEL
+set to 1 to display only warnings when memory is allocated or freed, and 2 to display all messages; the process started/terminated messages that include memory stats summary, as well as any error messages
+
+.TP
+.B __MEMORY_USAGE_LOG_FILE
+name of the log file associated with __MEMORY_USAGE_LOG_LEVEL, including 'stdout' and 'stderr', to which diagnostic messages for memory allocation and release are to be written
+
+.TP
+.B __RUNDEBUG
+set to toggle debug ZOSLIB mode
 
 .SH EXAMPLES
 To set the __UNTAGGED_READ_MODE environment variable to STRICT and disable explicit conversion of data:

--- a/test/test-clib-override.cc
+++ b/test/test-clib-override.cc
@@ -67,6 +67,60 @@ TEST_F(CLIBOverrides, open) {
     EXPECT_EQ(strcmp(buff, buff2), 0);
     close(fd);
 #endif
+
+    // Delete and re-open temp_path _ENCODE_FILE_NEW=IBM-1047
+    char buff[] = "This is a test";
+
+    setenv("_ENCODE_FILE_NEW", "IBM-1047", 1);
+    remove(temp_path);
+    fd = open(temp_path, O_CREAT | O_WRONLY, 0777);
+    EXPECT_EQ(__getfdccsid(fd), 0x10000 + 1047);
+    write(fd, buff, sizeof(buff));
+    close(fd);
+
+    fd = open(temp_path, O_RDONLY);
+    EXPECT_EQ(__getfdccsid(fd), 0x10000 + 1047);
+    char* buff2 = (char*)malloc(sizeof(buff));
+    memset(buff2, sizeof(buff), 1);
+    read(fd, buff2, sizeof(buff));
+    EXPECT_EQ(strcmp(buff, buff2), 0);
+    free(buff2);
+    close(fd);
+
+    // Delete and re-open temp_path _ENCODE_FILE_NEW=BINARY
+    setenv("_ENCODE_FILE_NEW", "BINARY", 1);
+    remove(temp_path);
+    fd = open(temp_path, O_CREAT | O_WRONLY, 0777);
+    EXPECT_EQ(__getfdccsid(fd), 65535);
+    write(fd, buff, sizeof(buff));
+    close(fd);
+
+    fd = open(temp_path, O_RDONLY);
+    EXPECT_EQ(__getfdccsid(fd), 65535);
+    buff2 = (char*)malloc(sizeof(buff));
+    memset(buff2, sizeof(buff), 1);
+    read(fd, buff2, sizeof(buff));
+    EXPECT_EQ(strcmp(buff, buff2), 0);
+    free(buff2);
+    close(fd);
+
+    // Delete and re-open temp_path _ENCODE_FILE_NEW=ISO8859-1
+    setenv("_ENCODE_FILE_NEW", "ISO8859-1", 1);
+    remove(temp_path);
+    fd = open(temp_path, O_CREAT | O_WRONLY, 0777);
+    EXPECT_EQ(__getfdccsid(fd), 0x10000 + 819);
+    write(fd, buff, sizeof(buff));
+    close(fd);
+
+    fd = open(temp_path, O_RDONLY);
+    EXPECT_EQ(__getfdccsid(fd), 0x10000 + 819);
+    buff2 = (char*)malloc(sizeof(buff));
+    memset(buff2, sizeof(buff), 1);
+    read(fd, buff2, sizeof(buff));
+    EXPECT_EQ(strcmp(buff, buff2), 0);
+    free(buff2);
+    close(fd);
+    unsetenv("_ENCODE_FILE_NEW");
 }
 
 TEST_F(CLIBOverrides, pipe) {


### PR DESCRIPTION
* Fixes man pages for zoslib, you can now type `man zoslib`
* Allows the new file ccsid to be configured via _ENCODE_FILE_NEW
* Useful if you want to create files in IBM-1047 or binary
example:

`_ENCODE_FILE_NEW=IBM-1047 echo "Hi" > file.txt`
file.txt will have the IBM-1047 file tag.
