### PR TITLE
Include features.h for __NATIVE_ASCII_F

### DIFF
--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -11,6 +11,7 @@
 
 #define __XPLAT 1
 #include "zos-macros.h"
+#include <features.h>
 
 
 #if defined(__cplusplus)

--- a/include/zos-v2r5-symbolfixes.h
+++ b/include/zos-v2r5-symbolfixes.h
@@ -44,7 +44,6 @@
 #pragma redefine_extname setresuid setresuid_undefined
 #pragma redefine_extname setresgid setresgid_undefined
 #pragma redefine_extname dup3 dup3_undefined
-#pragma redefine_extname flock flock_undefined
 #pragma redefine_extname shm_open shm_open_undefined
 #endif
 


### PR DESCRIPTION
* __NATIVE_ASCII_F is used in the stdlib.h header but is only defined in features.h (and not by the compiler). This is leading to issues when compiling some ports like tree and also wrongly mapping to the ebcdic functions.
* Also since flock is now defined in zoslib, we can remove it from `include/zos-v2r5-symbolfixes.h`