### PR TITLE
execvpe: Add call to confstr (_CS_PATH, dp, len);

### DIFF
--- a/src/zos.cc
+++ b/src/zos.cc
@@ -1476,9 +1476,10 @@ extern "C" int execvpe(const char *name, char *const argv[],
     // If PATH is not defined, get the default from confstr
     len = confstr(_CS_PATH, NULL, 0);
     if (len) {
-       dp = (char*)malloc(len + 1);
+       dp = (char*)malloc(len);
        if (dp == NULL)
          return errno ? errno : ENOMEM;
+       confstr (_CS_PATH, dp, len);
     } else
        len = 1;
   }


### PR DESCRIPTION
* This fixes a regression in GNU Make where the PATH enviroment variable is unset and then execvpe is called.
* It adds the call to `confstr (_CS_PATH, dp, len);` back from the zopen branch. This call copies the default PATH contents into dp.
* Also confstr considers the null terminator so len doesnt need a + 1