### PR TITLE
add support for posix_spawnp()

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -42,6 +42,7 @@ shared_library("zoslib") {
     "src/zos-getentropy.cc",
     "src/zos-io.cc",
     "src/zos-semaphore.cc",
+    "src/zos-spawn.cc",
     "src/zos-sys-info.cc",
     "src/zos-tls.cc",
   ]

--- a/include/spawn.h
+++ b/include/spawn.h
@@ -48,7 +48,11 @@ __Z_EXPORT int posix_spawnattr_setsigmask(posix_spawnattr_t *, sigset_t *mask);
 __Z_EXPORT int posix_spawnattr_setflags(posix_spawnattr_t *, short flags);
 __Z_EXPORT int posix_spawnattr_destroy(posix_spawnattr_t *);
 
-__Z_EXPORT int posix_spawn(pid_t *pid, const char *cmd,
+__Z_EXPORT int posix_spawn(pid_t *pid, const char *path,
+                const posix_spawn_file_actions_t *act,
+                const posix_spawnattr_t *, char *const args[],
+                char *const env[]);
+__Z_EXPORT int posix_spawnp(pid_t *pid, const char *file,
                 const posix_spawn_file_actions_t *act,
                 const posix_spawnattr_t *, char *const args[],
                 char *const env[]);

--- a/src/zos-spawn.cc
+++ b/src/zos-spawn.cc
@@ -15,6 +15,8 @@
 #define _POSIX_SOURCE
 #include <unistd.h>
 
+#include "zos-io.h"
+
 enum ActionKinds { op_open, op_close, op_dup2};
 struct _spawn_actions {
   ActionKinds op;
@@ -173,8 +175,10 @@ int posix_spawnattr_destroy(posix_spawnattr_t* attr) {
   return 0;
 }
 
-int posix_spawn(pid_t *pid, const char *cmd, const posix_spawn_file_actions_t *act, const posix_spawnattr_t* attr, char * const args[], char * const env[]) {
-
+int posix_spawn(pid_t *pid, const char *path,
+                const posix_spawn_file_actions_t *act,
+                const posix_spawnattr_t* attr,
+                char * const args[], char * const env[]) {
   if (pid==nullptr)
     return EINVAL;
 #if HAS_VFORK
@@ -228,12 +232,25 @@ int posix_spawn(pid_t *pid, const char *cmd, const posix_spawn_file_actions_t *a
             if ((rc=dup2(cur->fd, cur->new_fd)) < 0)
               return rc;
             break;
-          default: return 127;
+          default: return ENOENT;
         }
       }
     }
-  execve(cmd, args, env);
-  return 127;
+    execve(path, args, env);
+    return ENOENT;
   }
   return 0;
+}
+
+int posix_spawnp(pid_t *pid, const char *file,
+                const posix_spawn_file_actions_t *act,
+                const posix_spawnattr_t* attr,
+                char * const args[], char * const env[]) {
+  char filepath[PATH_MAX];
+  char *pathenv = getenv("PATH");
+  if (pathenv != NULL &&
+      __find_file_in_path(filepath, sizeof(filepath), pathenv, file) > 0) {
+    return posix_spawn(pid, filepath, act, attr, args, env);
+  }
+  return ENOENT;
 }


### PR DESCRIPTION
posix_spawnp() is required in [V8](https://v8.dev/).

Also return ENOENT (129) instead of 127 (ENFILE - " Too many open files in system"), where on other platforms 127 is ENOENT.  I don't know if 127 was hardcoded to comply with the linux [doc](https://linux.die.net/man/3/posix_spawnp).