### PR TITLE
Adding TLS workaroung for C applications

### DIFF
--- a/include/zos-tls.h
+++ b/include/zos-tls.h
@@ -38,38 +38,22 @@ public:
 
 #endif // __cplusplus
 
-/* 
-These macros provide a workaround for the non-existing thread local storage (TLS) 
-support for C applications on z/os. It leverages the pthread_key_create, pthread_getspecific 
-and pthread_setspecific calls to acheve TLS.
-*/
 
-static void tls_destructor(void *value) {
-    free(value);
+struct __tlsanchor {
+  pthread_once_t once;
+  pthread_key_t key;
+  size_t sz;
+};
+
+typedef struct __tlsanchor tls_t;
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+void * __tlsValue(tls_t *);
+char** __tlsArray(tls_t *,int ,int);
+#if defined(__cplusplus)
 }
+#endif
 
-#define GET_KEY_VAL(key_name, key_status, val, size) \
-   if(key_status == 0){\
-      int resp = pthread_key_create(&key_name, tls_destructor);  \
-      assert(resp == 0);\
-      key_status = 1;\
-   } \
-   val = pthread_getspecific(key_name); \
-    if (val == NULL) \
-    { \
-        val = calloc(1,size);\
-        assert(val != NULL);\
-    }
-
-#define SET_KEY_VAL(key_name,val) \
-pthread_setspecific(key_name,val);
-
-#define GET_KEY_VAL_ARRAY(key_name,key_status, val, size, rows, columns)\
-GET_KEY_VAL(key_name,key_status, val, ((rows*sizeof(char *))+(rows*columns*size))) \
-{\
-char *data_start = (char *)(val + rows);\
-    for (int i = 0; i < rows; i++) { \
-        val[i] = data_start + i * columns;\
-    } \
-}
 #endif // ZOS_TLS_H_

--- a/include/zos-tls.h
+++ b/include/zos-tls.h
@@ -37,4 +37,39 @@ public:
 };
 
 #endif // __cplusplus
+
+/* 
+These macros provide a workaround for the non-existing thread local storage (TLS) 
+support for C applications on z/os. It leverages the pthread_key_create, pthread_getspecific 
+and pthread_setspecific calls to acheve TLS.
+*/
+
+static void tls_destructor(void *value) {
+    free(value);
+}
+
+#define GET_KEY_VAL(key_name, key_status, val, size) \
+   if(key_status == 0){\
+      int resp = pthread_key_create(&key_name, tls_destructor);  \
+      assert(resp == 0);\
+      key_status = 1;\
+   } \
+   val = pthread_getspecific(key_name); \
+    if (val == NULL) \
+    { \
+        val = calloc(1,size);\
+        assert(val != NULL);\
+    }
+
+#define SET_KEY_VAL(key_name,val) \
+pthread_setspecific(key_name,val);
+
+#define GET_KEY_VAL_ARRAY(key_name,key_status, val, size, rows, columns)\
+GET_KEY_VAL(key_name,key_status, val, ((rows*sizeof(char *))+(rows*columns*size))) \
+{\
+char *data_start = (char *)(val + rows);\
+    for (int i = 0; i < rows; i++) { \
+        val[i] = data_start + i * columns;\
+    } \
+}
 #endif // ZOS_TLS_H_

--- a/src/zos-tls.cc
+++ b/src/zos-tls.cc
@@ -93,23 +93,22 @@ void *__tlsPtrFromAnchor(struct __tlsanchor *anchor, const void *initvalue) {
   return __tlsPtrAlloc(anchor->sz, &(anchor->key), &(anchor->once), initvalue);
 }
 void * __tlsValue(tls_t *a) {
-	char * initvalue = NULL;
-	void *val = NULL;
-	initvalue = (char *)malloc(sizeof(char)*(a->sz));
-	assert(initvalue != NULL);
-	bzero(initvalue,a->sz);
-	val = __tlsPtrAlloc(a->sz, &(a->key), &(a->once),(void *)initvalue);
-	free(initvalue);
-	return val;
+  void *val = NULL;
+  char * initvalue = (char *)malloc(sizeof(char)*(a->sz));
+  assert(initvalue != NULL);
+  bzero(initvalue,a->sz);
+  val = __tlsPtrAlloc(a->sz, &(a->key), &(a->once),(void *)initvalue);
+  free(initvalue);
+  return val;
 }
 
 char** __tlsArray(tls_t *a, int rows, int columns) {
-	char **val = NULL;
-	a->sz = ((rows*sizeof(char *))+(rows*columns*(a->sz)));
-	val = (char **)__tlsValue(a);
-	for (int i = 0; i < rows; i++) {
-		      val[i] = (char*)(val + rows) + i * columns;
-		}
-	return val;
+  char **val = NULL;
+  a->sz = ((rows*sizeof(char *))+(rows*columns*(a->sz)));
+  val = (char **)__tlsValue(a);
+  for (int i = 0; i < rows; i++) {
+    val[i] = (char*)(val + rows) + i * columns;
+  }
+  return val;
 }
 

--- a/src/zos-tls.cc
+++ b/src/zos-tls.cc
@@ -74,11 +74,6 @@ static void *__tlsPtr(pthread_key_t *key) { return pthread_getspecific(*key); }
 static void __tlsDelete(pthread_key_t *key) { pthread_key_delete(*key); }
 #endif
 
-struct __tlsanchor {
-  pthread_once_t once;
-  pthread_key_t key;
-  size_t sz;
-};
 
 struct __tlsanchor *__tlsvaranchor_create(size_t sz) {
   struct __tlsanchor *a =
@@ -96,3 +91,18 @@ void __tlsvaranchor_destroy(struct __tlsanchor *anchor) {
 void *__tlsPtrFromAnchor(struct __tlsanchor *anchor, const void *initvalue) {
   return __tlsPtrAlloc(anchor->sz, &(anchor->key), &(anchor->once), initvalue);
 }
+void * __tlsValue(tls_t *a) {
+	const int initvalue = 0;
+	return __tlsPtrAlloc(a->sz, &(a->key), &(a->once),(void *)&initvalue);
+}
+
+char** __tlsArray(tls_t *a, int rows, int columns) {
+	char ** val = NULL;
+	a->sz = ((rows*sizeof(char *))+(rows*columns*(a->sz)));
+	val = (char **)__tlsValue(a);
+	for (int i = 0; i < rows; i++) {
+		      val[i] = (char*)(val + rows) + i * columns;
+		}
+	return val;
+}
+

--- a/src/zos-tls.cc
+++ b/src/zos-tls.cc
@@ -12,6 +12,7 @@
 #include <pthread.h>
 #include <stdlib.h>
 #include <string.h>
+#include <assert.h>
 
 static void _cleanup(void *p) {
   pthread_key_t key = *((pthread_key_t *)p);
@@ -92,12 +93,18 @@ void *__tlsPtrFromAnchor(struct __tlsanchor *anchor, const void *initvalue) {
   return __tlsPtrAlloc(anchor->sz, &(anchor->key), &(anchor->once), initvalue);
 }
 void * __tlsValue(tls_t *a) {
-	const int initvalue = 0;
-	return __tlsPtrAlloc(a->sz, &(a->key), &(a->once),(void *)&initvalue);
+	char * initvalue = NULL;
+	void *val = NULL;
+	initvalue = (char *)malloc(sizeof(char)*(a->sz));
+	assert(initvalue != NULL);
+	bzero(initvalue,a->sz);
+	val = __tlsPtrAlloc(a->sz, &(a->key), &(a->once),(void *)initvalue);
+	free(initvalue);
+	return val;
 }
 
 char** __tlsArray(tls_t *a, int rows, int columns) {
-	char ** val = NULL;
+	char **val = NULL;
 	a->sz = ((rows*sizeof(char *))+(rows*columns*(a->sz)));
 	val = (char **)__tlsValue(a);
 	for (int i = 0; i < rows; i++) {


### PR DESCRIPTION
Introducing macros to workaround the non-existent TLS support for C applications on z/OS