### PR TITLE
add support for %PPID%, %PID% in log filename & refactor

### DIFF
--- a/include/zos-base.h
+++ b/include/zos-base.h
@@ -565,29 +565,6 @@ unsigned long __get_libvec_base(void);
 __Z_EXPORT int __update_envar_names(zoslib_config_t *const config);
 
 /**
- * Returns true if logging of memory allocation and release is specified.
- */
-__Z_EXPORT bool __doLogMemoryUsage();
-
-/**
- * Returns the file name, including "stdout" or "stderr", used to log memory
- * allocation and release to.
- */
-__Z_EXPORT char *__getMemoryUsageLogFile();
-
-/**
- * Returns true if all messages from memory allocation and release are being
- * displayed.
- */
-__Z_EXPORT bool __doLogMemoryAll();
-
-/**
- * Returns true if only warnings from memory allocation and release are being
- * displayed. Errors are always included if memory logging in on.
- */
-__Z_EXPORT bool __doLogMemoryWarning();
-
-/**
  * Tell zoslib that the main process is terminating, for its diagnostics.
  *
  */

--- a/include/zos-io.h
+++ b/include/zos-io.h
@@ -148,6 +148,29 @@ __Z_EXPORT int __getfdccsid(int fd);
 __Z_EXPORT int __setfdccsid(int fd, int t_ccsid);
 
 /**
+ * Returns true if logging of memory allocation and release is specified.
+ */
+__Z_EXPORT bool __doLogMemoryUsage();
+
+/**
+ * Returns the file name, including "stdout" or "stderr", used to log memory
+ * allocation and release to.
+ */
+__Z_EXPORT char *__getMemoryUsageLogFile();
+
+/**
+ * Returns true if all messages from memory allocation and release are being
+ * displayed.
+ */
+__Z_EXPORT bool __doLogMemoryAll();
+
+/**
+ * Returns true if only warnings from memory allocation and release are being
+ * displayed. Errors are always included if memory logging in on.
+ */
+__Z_EXPORT bool __doLogMemoryWarning();
+
+/**
  * Returns the fileno to which memory diagnostics is written (use for
  * instance in a `__display_backtrace(__getLogMemoryFileNo());` call).
  */


### PR DESCRIPTION
The updates here were done in older versions of the internal zoslib.
* Use new getMemUsageLogFilename() to determine the actual log filename; it supports %PPID% and %PID% in the user-provided name in __MEMORY_USAGE_LOG_FILE, and therefore a separate log file for each process is created, in which case the 'pid=process-id' is not logged to reduce file size.
* Include the parent process name and pid in the TERMINATING message.
* Move the memory logging code to zos-io.cc.