### PR TITLE
fix 0C4 in backtrace_symbols_fd + support new envar __MEMORY_USAGE_LOG_INC

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -64,7 +64,9 @@ fi
 pushd build
 export MAKEFLAGS='-j4'
 
-cmake .. -DCMAKE_C_COMPILER=${CC} -DCMAKE_CXX_COMPILER=${CXX} -DCMAKE_ASM_COMPILER=${CC} ${BLD_TESTS} -DCMAKE_BUILD_TYPE=${BLD_TYPE} -DCMAKE_INSTALL_PREFIX=${SCRIPT_DIR}/install
+if((IS_CLEAN==1)) || ! test -s CMakeCache.txt; then
+  cmake .. -DCMAKE_C_COMPILER=${CC} -DCMAKE_CXX_COMPILER=${CXX} -DCMAKE_ASM_COMPILER=${CC} ${BLD_TESTS} -DCMAKE_BUILD_TYPE=${BLD_TYPE} -DCMAKE_INSTALL_PREFIX=${SCRIPT_DIR}/install
+fi
 cmake --build . --target install
 
 popd

--- a/include/zos-base.h
+++ b/include/zos-base.h
@@ -47,6 +47,7 @@
 #define UNTAGGED_READ_MODE_CCSID1047_DEFAULT "__UNTAGGED_READ_MODE_CCSID1047"
 #define MEMORY_USAGE_LOG_FILE_ENVAR_DEFAULT "__MEMORY_USAGE_LOG_FILE"
 #define MEMORY_USAGE_LOG_LEVEL_ENVAR_DEFAULT "__MEMORY_USAGE_LOG_LEVEL"
+#define MEMORY_USAGE_LOG_INC_ENVAR_DEFAULT "__MEMORY_USAGE_LOG_INC"
 
 typedef enum {
   __NO_TAG_READ_DEFAULT = 0,
@@ -482,6 +483,12 @@ typedef struct __Z_EXPORT zoslib_config {
    */
   const char *MEMORY_USAGE_LOG_LEVEL_ENVAR =
               MEMORY_USAGE_LOG_LEVEL_ENVAR_DEFAULT;
+  /**
+   * String to indicate the envar to be used to specify the increase in memory
+   * allocated, in bytes, after which logging occurs.
+   */
+  const char *MEMORY_USAGE_LOG_INC_ENVAR = MEMORY_USAGE_LOG_INC_ENVAR_DEFAULT;
+
 } zoslib_config_t;
 
 /**

--- a/include/zos-io.h
+++ b/include/zos-io.h
@@ -171,7 +171,7 @@ __Z_EXPORT bool __doLogMemoryAll();
 __Z_EXPORT bool __doLogMemoryWarning();
 
 /**
- * Returns true if memory allocation should be displayed when curvar increases
+ * Returns true if memory allocation should be displayed when curval increases
  * by the value set in environment variable __MEMORY_USAGE_LOG_INC since the last
  * currently allocated size was displayed.
  */

--- a/include/zos-io.h
+++ b/include/zos-io.h
@@ -171,6 +171,13 @@ __Z_EXPORT bool __doLogMemoryAll();
 __Z_EXPORT bool __doLogMemoryWarning();
 
 /**
+ * Returns true if memory allocation should be displayed when curvar increases
+ * by the value set in environment variable __MEMORY_USAGE_LOG_INC since the last
+ * currently allocated size was displayed.
+ */
+__Z_EXPORT bool __doLogMemoryInc(size_t curval, size_t *plastval);
+
+/**
  * Returns the fileno to which memory diagnostics is written (use for
  * instance in a `__display_backtrace(__getLogMemoryFileNo());` call).
  */

--- a/src/zos-io.cc
+++ b/src/zos-io.cc
@@ -29,6 +29,7 @@ const char MEMLOG_LEVEL_WARNING = '1';
 const char MEMLOG_LEVEL_ALL = '2';
 
 char __gMemoryUsageLogFile[PATH_MAX] = "";
+size_t __gLogMemoryInc = 0u;
 bool __gLogMemoryUsage = false;
 bool __gLogMemoryAll = false;
 bool __gLogMemoryWarning = false;
@@ -1034,6 +1035,27 @@ void update_memlogging_level(__zinit *zinit_ptr, const char *envar) {
     else if (*penv == MEMLOG_LEVEL_WARNING)
       __gLogMemoryWarning = true; // warnings only
   }
+}
+
+void update_memlogging_inc(__zinit *zinit_ptr, const char *envar) {
+  if (!zinit_ptr)
+    return;
+  zoslib_config_t &config = zinit_ptr->config;
+
+  char *penv = getenv(config.MEMORY_USAGE_LOG_INC_ENVAR);
+  if (penv && __doLogMemoryUsage()) {
+    __gLogMemoryInc = atol(penv);
+  }
+}
+
+bool __doLogMemoryInc(size_t curval, size_t *plastval) {
+  if (!__doLogMemoryUsage() || __gLogMemoryInc == 0u)
+    return false;
+  if (curval > *plastval && ((curval - *plastval) / __gLogMemoryInc) > 0) {
+    *plastval = curval;
+    return true;
+  }
+  return false;
 }
 
 bool __doLogMemoryUsage() { return __gLogMemoryUsage; }

--- a/src/zos.cc
+++ b/src/zos.cc
@@ -358,7 +358,8 @@ void backtrace_symbols_w(void *const *buffer, int size, int fd,
       if (fc.tok_sev >= 2) {
         dprintf(2, "____le_traceback_a() service failed\n");
         free(return_buff);
-        *return_string = 0;
+        if (return_string != nullptr)
+          *return_string = 0;
         return;
       }
       caller_dsa = tbck_parms.__tf_caller_dsa_addr;
@@ -430,7 +431,8 @@ void backtrace_symbols_w(void *const *buffer, int size, int fd,
       if (i == size) {
         // return &table[0];
         table[i] = 0;
-        *return_string = &table[0];
+        if (return_string != nullptr)
+          *return_string = &table[0];
         return;
       }
       free(return_buff);

--- a/src/zos.cc
+++ b/src/zos.cc
@@ -117,6 +117,7 @@ const char *__zoslib_version = DEFAULT_BUILD_STRING;
 extern "C" void __set_ccsid_guess_buf_size(int nbytes);
 extern "C" void update_memlogging(__zinit *, const char *envar);
 extern "C" void update_memlogging_level(__zinit *, const char *envar);
+extern "C" void update_memlogging_inc(__zinit *, const char *envar);
 
 #ifndef max
 #define max(a, b) (((a) > (b)) ? (a) : (b))
@@ -2285,6 +2286,9 @@ int __update_envar_settings(const char *envar) {
   if (force_update_all || strcmp(envar, config.MEMORY_USAGE_LOG_LEVEL_ENVAR) == 0)
     update_memlogging_level(zinit_ptr, envar);
  
+  if (force_update_all || strcmp(envar, config.MEMORY_USAGE_LOG_INC_ENVAR) == 0)
+    update_memlogging_inc(zinit_ptr, envar);
+
   return 0;
 }
 


### PR DESCRIPTION
- Check result_string pointer before writing to it; `backtrace_symbols_fd()` calls `backtrace_symbols_w()` with arg `result_string` set to 0, which causes a 0C4 when return_string is writen to.
- Add support for envar `__MEMORY_USAGE_LOG_INC`. This tells zoslib to display memory allocation messages only when the current allocated size increases by the given value (in bytes). The intent is to reduce the size of the log file esp for long-running apps, which for this to be enabled, the current `__MEMORY_USAGE_LOG_LEVEL` envar should be set to 0.
- build.sh: run cmake only if clean build was requested or build/CMakeCache.txt doesn't exist or is empty.