### PR TITLE
Various enhancements for zopen tools

### DIFF
--- a/include/pthread.h
+++ b/include/pthread.h
@@ -1,0 +1,51 @@
+///////////////////////////////////////////////////////////////////////////////
+// Licensed Materials - Property of IBM
+// ZOSLIB
+// (C) Copyright IBM Corp. 2021. All Rights Reserved.
+// US Government Users Restricted Rights - Use, duplication
+// or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef ZOS_PTHREAD_H_
+#define ZOS_PTHREAD_H_
+
+#define __XPLAT 1
+#include "zos-macros.h"
+#include <sys/types.h>
+
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+__Z_EXPORT int __pthread_create_extended(pthread_t *thread,
+                          const pthread_attr_t *attr,
+                          void *(*start_routine)(void *),
+                          void *arg); 
+#if defined(__cplusplus)
+}
+#endif
+
+#if defined(ZOSLIB_OVERRIDE_CLIB) || defined(ZOSLIB_OVERRIDE_CLIB_PTHREAD)
+#define pthread_create __pthread_create_replaced
+#endif
+
+#include_next <pthread.h>
+
+#if defined(ZOSLIB_OVERRIDE_CLIB) || defined(ZOSLIB_OVERRIDE_CLIB_PTHREAD)
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+#undef pthread_create 
+__Z_EXPORT int pthread_create(pthread_t *thread,
+                          const pthread_attr_t *attr,
+                          void *(*start_routine)(void *),
+                          void *arg) asm("__pthread_create_extended");
+
+#if defined(__cplusplus)
+}
+#endif
+#endif /* defined(ZOSLIB_OVERRIDE_CLIB) || defined(ZOSLIB_OVERRIDE_CLIB_PTHREAD) */
+
+#endif

--- a/src/zos-char-util.cc
+++ b/src/zos-char-util.cc
@@ -538,27 +538,25 @@ int __file_needs_conversion_init(const char *name, int fd) {
       close(fd);
       return 0;
     }
-    if (cnt > 8) {
-      int ccsid;
-      int am;
-      unsigned len = strlen_ae((unsigned char *)buf, &ccsid, cnt, &am);
-      if (ccsid == 1047 && len == cnt) {
-        if (no_tag_read_behaviour == __NO_TAG_READ_DEFAULT_WITHWARNING) {
-          if (name) {
-            len = strlen(name) + 1;
-            char filename[len];
-            _convert_e2a(filename, name, len);
-            dprintf(2, "Warning: File \"%s\" is untagged and seems to contain "
-                       "EBCDIC characters\n", filename);
-          } else {
-            dprintf(2, "Warning: File (null) is untagged and seems to contain "
-                       "EBCDIC characters\n");
-          }
+    int ccsid;
+    int am;
+    unsigned len = strlen_ae((unsigned char *)buf, &ccsid, cnt, &am);
+    if (ccsid == 1047 && len == cnt) {
+      if (no_tag_read_behaviour == __NO_TAG_READ_DEFAULT_WITHWARNING) {
+        if (name) {
+          len = strlen(name) + 1;
+          char filename[len];
+          _convert_e2a(filename, name, len);
+          dprintf(2, "Warning: File \"%s\" is untagged and seems to contain "
+                      "EBCDIC characters\n", filename);
+        } else {
+          dprintf(2, "Warning: File (null) is untagged and seems to contain "
+                      "EBCDIC characters\n");
         }
-        fdcache.set_attribute(fd, 0x0000000000020000UL);
-        return 1;
       }
-    }       // cnt > 8
+      fdcache.set_attribute(fd, 0x0000000000020000UL);
+      return 1;
+    }
   }         // seekable files
   return 0; // not seekable
 }

--- a/test/test-thread.cc
+++ b/test/test-thread.cc
@@ -1,0 +1,49 @@
+// Enable CLIB overrides
+#define ZOSLIB_OVERRIDE_CLIB 1
+
+#include "zos.h"
+#include "gtest/gtest.h"
+#include <sys/file.h>
+#include <sys/wait.h>
+#include <stdio.h>
+#include <pthread.h>
+
+int cvsstate = 0;
+
+namespace {
+
+void* print_cvstate(void* arg) {
+  int* cvsstate_ptr = static_cast<int*>(arg);
+  *cvsstate_ptr = __ae_autoconvert_state(_CVTSTATE_QUERY);
+
+  return NULL;
+}
+
+TEST(CvstateTest, PrintCvstate) {
+  {
+  int cvsstate = 0;
+  unsetenv("_BPXK_AUTOCVT");
+
+  pthread_t thread;
+  pthread_create(&thread, NULL, &print_cvstate, &cvsstate);
+
+  pthread_join(thread, NULL);
+
+  EXPECT_EQ(cvsstate, _CVTSTATE_ON);
+  }
+
+  {
+  int cvsstate = 0;
+  setenv("_BPXK_AUTOCVT", "ON", 1);
+
+  pthread_t thread;
+  pthread_create(&thread, NULL, &print_cvstate, &cvsstate);
+
+  pthread_join(thread, NULL);
+
+  EXPECT_EQ(cvsstate, _CVTSTATE_ON);
+  }
+}
+
+}
+


### PR DESCRIPTION
  - pthread_create-created threads do not set autocvt by default. This can be problematic if _BPXK_AUTOCVT is unset in the user environment. This PR adds a change to override pthread_create which sets AUTOCVT=ON in a similar way to the startup routine in zos.cc.
  - IT also modifies the untagged read heuristic to remove the restriction on the min required bytes (currently set to 8 bytes). The reason for this is that there are <8 byte EBCDIC files such as /etc/syslog.pid and /etc/sshd.pid and based on user experience, untagged files which are small in size typically contain EBCDIC data and not binary data or ascii data so we should lean towards marking it as EBCDIC. Additionally, all z/OS Open Tools tag their data. Note, the __UNTAGGED_READ_MODE environment variable still takes precedence when set but most users do not set this environment variable.
    - This will help resolve:
      - https://github.com/ZOSOpenTools/nanoport/issues/11
      - https://github.com/ZOSOpenTools/vimport/issues/52
      - https://github.com/ZOSOpenTools/coreutilsport/issues/68
      - https://github.com/ZOSOpenTools/nanoport/issues/5
  - Also changes chgfdccsid to not set the txtflag when ccsid = 0
  - Adds more tests