### PR TITLE
rename macro NR and make last_ccsid from strlen_ae() thread-safe with tls

### DIFF
--- a/include/zos-base.h
+++ b/include/zos-base.h
@@ -31,10 +31,12 @@
 
 #define __ZOS_CC
 
+// XL-specific NR parameter constraint:
+// https://www.ibm.com/docs/en/zos/2.4.0?topic=statements-inline-assembly-extension
 #if __clang_major__ < 18
-#define NR(attr,reg) attr "NR:" #reg
+#define __ZL_NR(attr,reg) attr "NR:" #reg
 #else
-#define NR(attr,reg) attr "{" #reg "}"
+#define __ZL_NR(attr,reg) attr "{" #reg "}"
 #endif 
 
 #include "zos-macros.h"

--- a/include/zos-char-util.h
+++ b/include/zos-char-util.h
@@ -174,8 +174,8 @@ inline void* __Z_EXPORT __convert_one_to_one(const void *table, void *dst,
                                              size_t size, const void *src) {
   void *rst = dst;
   __asm volatile(" troo 2,%2,1 \n jo *-4 \n"
-                 : NR("+",r3)(size), NR("+",r2)(dst), "+r"(src)
-                 : NR("",r1)(table)
+                 : __ZL_NR("+",r3)(size), __ZL_NR("+",r2)(dst), "+r"(src)
+                 : __ZL_NR("",r1)(table)
                  : "r0");
   return rst;
 }
@@ -238,8 +238,8 @@ inline unsigned strlen_ae(const unsigned char *str, int *code_page,
   start = str;
   __asm volatile(" trte %1,%3,0\n"
                  " jo *-4\n"
-                 : NR("+",r3)(bytes), NR("+",r2)(str), "+r"(bytes), "+r"(code_out)
-                 : NR("",r1)(_tab_a)
+                 : __ZL_NR("+",r3)(bytes), __ZL_NR("+",r2)(str), "+r"(bytes), "+r"(code_out)
+                 : __ZL_NR("",r1)(_tab_a)
                  :);
   unsigned a_len = str - start;
 
@@ -248,8 +248,8 @@ inline unsigned strlen_ae(const unsigned char *str, int *code_page,
   str = start;
   __asm volatile(" trte %1,%3,0\n"
                  " jo *-4\n"
-                 : NR("+",r3)(bytes), NR("+",r2)(str), "+r"(bytes), "+r"(code_out)
-                 : NR("",r1)(_tab_e)
+                 : __ZL_NR("+",r3)(bytes), __ZL_NR("+",r2)(str), "+r"(bytes), "+r"(code_out)
+                 : __ZL_NR("",r1)(_tab_e)
                  :);
   unsigned e_len = str - start;
   if (a_len > e_len) {
@@ -289,8 +289,8 @@ inline unsigned strlen_e(const unsigned char *str, unsigned size) {
 
   __asm volatile(" trte %1,%3,0\n"
                  " jo *-4\n"
-                 : NR("+",r3)(bytes), NR("+",r2)(str), "+r"(bytes), "+r"(code_out)
-                 : NR("",r1)(_tab_e)
+                 : __ZL_NR("+",r3)(bytes), __ZL_NR("+",r2)(str), "+r"(bytes), "+r"(code_out)
+                 : __ZL_NR("",r1)(_tab_e)
                  :);
 
   return str - start;

--- a/include/zos-char-util.h
+++ b/include/zos-char-util.h
@@ -200,73 +200,8 @@ public:
 
 #endif // ifdef __cplusplus
 
-inline unsigned strlen_ae(const unsigned char *str, int *code_page,
-                          unsigned long max_len, int *ambiguous) {
-  static int last_ccsid = 819;
-  static const unsigned char _tab_a[256] __attribute__((aligned(8))) = {
-      1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-      1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-      0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-      1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-      1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-      1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-      1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-      1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-  };
-  static const unsigned char _tab_e[256] __attribute__((aligned(8))) = {
-      1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1,
-      1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0,
-      1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1,
-      1, 1, 1, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0,
-      0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1,
-      1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1,
-      1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0,
-      0, 0, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1,
-      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0,
-      0, 0, 1, 1, 1, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1,
-      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1,
-  };
-  unsigned long bytes;
-  unsigned long code_out;
-  const unsigned char *start;
-
-  bytes = max_len;
-  code_out = 0;
-  start = str;
-  __asm volatile(" trte %1,%3,0\n"
-                 " jo *-4\n"
-                 : __ZL_NR("+",r3)(bytes), __ZL_NR("+",r2)(str), "+r"(bytes), "+r"(code_out)
-                 : __ZL_NR("",r1)(_tab_a)
-                 :);
-  unsigned a_len = str - start;
-
-  bytes = max_len;
-  code_out = 0;
-  str = start;
-  __asm volatile(" trte %1,%3,0\n"
-                 " jo *-4\n"
-                 : __ZL_NR("+",r3)(bytes), __ZL_NR("+",r2)(str), "+r"(bytes), "+r"(code_out)
-                 : __ZL_NR("",r1)(_tab_e)
-                 :);
-  unsigned e_len = str - start;
-  if (a_len > e_len) {
-    *code_page = 819;
-    last_ccsid = 819;
-    *ambiguous = 0;
-    return a_len;
-  } else if (e_len > a_len) {
-    *code_page = 1047;
-    last_ccsid = 1047;
-    *ambiguous = 0;
-    return e_len;
-  }
-  *code_page = last_ccsid;
-  *ambiguous = 1;
-  return a_len;
-}
+__Z_EXPORT unsigned strlen_ae(const unsigned char *str, int *code_page,
+                              unsigned long max_len, int *ambiguous);
 
 inline unsigned strlen_e(const unsigned char *str, unsigned size) {
   static const unsigned char _tab_e[256] __attribute__((aligned(8))) = {

--- a/src/zos-bpx.cc
+++ b/src/zos-bpx.cc
@@ -61,8 +61,8 @@ char *__realpath(const char *path, char *resolved_path) {
    path_resolved_len=strlen(resolved_path);
    const void *argv[] = {&path_len, ebcdic_path, &path_resolved_len, resolved_path, &rv, &rc, &rn};
    __asm volatile(" basr 14,%0\n"
-                  : NR("+",r15)(reg15)
-                  : NR("",r1)(&argv)
+                  : __ZL_NR("+",r15)(reg15)
+                  : __ZL_NR("",r1)(&argv)
                   : "r0", "r14");
    free(ebcdic_path);
    if (-1 == rv) {
@@ -97,8 +97,8 @@ void __bpx4kil(int pid, int signal, void *signal_options, int *return_value,
   void *argv[] = {&pid,         &signal,     signal_options,
                   return_value, return_code, reason_code}; // os style parm list
   __asm volatile(" basr 14,%0\n"
-                 : NR("+",r15)(reg15)
-                 : NR("",r1)(&argv)
+                 : __ZL_NR("+",r15)(reg15)
+                 : __ZL_NR("",r1)(&argv)
                  : "r0", "r14");
 }
 
@@ -106,8 +106,8 @@ void __bpx4frk(int *pid, int *return_code, int *reason_code) {
   void *reg15 = __uss_base_address()[240 / 4];    // BPX4FRK offset is 240
   void *argv[] = {pid, return_code, reason_code}; // os style parm list
   __asm volatile(" basr 14,%0\n"
-                 : NR("+",r15)(reg15)
-                 : NR("",r1)(&argv)
+                 : __ZL_NR("+",r15)(reg15)
+                 : __ZL_NR("",r1)(&argv)
                  : "r0", "r14");
 }
 
@@ -119,8 +119,8 @@ void __bpx4ctw(unsigned int *secs, unsigned int *nsecs,
   void *argv[] = {secs,         nsecs,       event_list, secs_rem, nsecs_rem,
                   return_value, return_code, reason_code}; // os style parm list
   __asm volatile(" basr 14,%0\n"
-                 : NR("+",r15)(reg15)
-                 : NR("",r1)(&argv)
+                 : __ZL_NR("+",r15)(reg15)
+                 : __ZL_NR("",r1)(&argv)
                  : "r0", "r14");
 }
 
@@ -135,8 +135,8 @@ void __bpx4gth(int *input_length, void **input_address, int *output_length,
                   return_value, return_code,   reason_code};
 
   __asm volatile(" basr 14,%0\n"
-                 : NR("+",r15)(reg15)
-                 : NR("",r1)(&argv)
+                 : __ZL_NR("+",r15)(reg15)
+                 : __ZL_NR("",r1)(&argv)
                  : "r0");
 }
 
@@ -151,8 +151,8 @@ void __bpx4lcr(int pathname_length, char *pathname, int attributes_length,
                   return_value,     return_code, reason_code};
 
   __asm volatile(" basr 14,%0\n"
-                 : NR("+",r15)(reg15)
-                 : NR("",r1)(&argv)
+                 : __ZL_NR("+",r15)(reg15)
+                 : __ZL_NR("",r1)(&argv)
                  : "r0", "r14");
 }
 

--- a/src/zos-getentropy.cc
+++ b/src/zos-getentropy.cc
@@ -96,7 +96,7 @@ extern "C" int getentropy(void* output, size_t size) {
       __asm volatile(" prno 8,10\n"
             " jo *-4\n"
             :
-            : NR("",r0)(0), NR("",r1)(&value)
+            : __ZL_NR("",r0)(0), __ZL_NR("",r1)(&value)
             :);
     if (0x2000 & value.b) {
         feature = 1;
@@ -127,15 +127,15 @@ extern "C" int getentropy(void* output, size_t size) {
   long first_operand_length = 0;
   __asm volatile(" prno 10,2\n"
         " jo *-4\n"
-        : NR("+",r2)(out), NR("+",r3)(size)
-        : NR("",r0)(114), NR("",r11)(first_operand_length)
+        : __ZL_NR("+",r2)(out), __ZL_NR("+",r3)(size)
+        : __ZL_NR("",r0)(114), __ZL_NR("",r11)(first_operand_length)
         :);
 
 #else
   __asm(" prno 8,10\n"
       " jo *-4\n"
-      : NR("+",r10)(out), NR("+",r11)(size)
-      : NR("",r0)(114), NR("",r9)(0)
+      : __ZL_NR("+",r10)(out), __ZL_NR("+",r11)(size)
+      : __ZL_NR("",r0)(114), __ZL_NR("",r9)(0)
       : "r0");
 #endif
   return 0;

--- a/src/zos-string.c
+++ b/src/zos-string.c
@@ -118,7 +118,7 @@ size_t strnlen(const char *str, size_t maxlen) {
   asm volatile(" SRST %0,%1\n"
                " jo *-4"
                : "+r"(op1), "+r"(op2)
-               : NR("",r0)(0)
+               : __ZL_NR("",r0)(0)
                :);
   return op1 - str;
 

--- a/src/zos.cc
+++ b/src/zos.cc
@@ -464,7 +464,7 @@ void __abend(int comp_code, unsigned reason_code, int flat_byte, void *plist) {
   r1 = (flat_byte << 24) + (0x00ffffff & comp_code);
   __asm volatile(" SVC 13\n"
                  :
-                 : NR("",r0)(r0), NR("",r1)(r1), NR("",r15)(r15)
+                 : __ZL_NR("",r0)(r0), __ZL_NR("",r1)(r1), __ZL_NR("",r15)(r15)
                  :);
 }
 
@@ -1097,7 +1097,7 @@ static long long __iarv64(void *parm, long long *reason_code_ptr) {
   char *code = ((char *__ptr32 *__ptr32 *__ptr32 *)0)[4][193][52];
   code = (char *)(((unsigned long long)code) | 14); // offset to the entry
   asm volatile(" PC 0(%3)"
-               : NR("=",r0)(reason), NR("+",r1)(parm), NR("=",r15)(rc)
+               : __ZL_NR("=",r0)(reason), __ZL_NR("+",r1)(parm), __ZL_NR("=",r15)(rc)
                : "a"(code)
                : );
   rc = (rc & 0x0ffff);
@@ -2146,8 +2146,8 @@ unsigned long long __registerProduct(const char *major_version,
 
   // Load 25 (IFAUSAGE) into reg15 and call via SVC
   asm volatile(" svc 109\n"
-               : NR("=",r15)(ifausage_rc)
-               : NR("",r1)(arg), NR("",r15)(25)
+               : __ZL_NR("=",r15)(ifausage_rc)
+               : __ZL_NR("",r1)(arg), __ZL_NR("",r15)(25)
                :);
 
   free(arg);


### PR DESCRIPTION
- rename macro NR, as it may conflict with user identifier having same name.
- move strlen_ae() to zos-char-util.cc. This resolves warning: non-constant static local variable in inline function may be different in different files. Also make last_ccsid thread-safe with tls.