### PR TITLE
Add V2R5 PTFs back in

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ with z/OS UNIX System Services enabled:
   - UI64940
   - UI65567
 - z/OS V2R5
+  - UI78912
+  - UI81095
+  - UI80156
+  - UI83424
 - z/OS V3R1
 
 ZOSLIB is supported on the following hardware:

--- a/mainpage/mainpage.dox
+++ b/mainpage/mainpage.dox
@@ -31,7 +31,6 @@ These are the main headers for ZOSLIB:
 - @ref include/zos-tls.h
 
 ZOSLIB also overrides the following LE headers:
-
 - @ref include/fcntl.h
 - @ref include/limits.h
 - @ref include/mntent.h

--- a/mainpage/mainpage.dox
+++ b/mainpage/mainpage.dox
@@ -20,7 +20,12 @@ The API documentation for ZOSLIB is provided within the library's headers.
 These are the main headers for ZOSLIB:
 - @ref include/zos.h
 - @ref include/zos-base.h
+- @ref include/zos-bpx.h
+- @ref include/zos-char-util.h
+- @ref include/zos-getentropy.h
+- @ref include/zos-io.h
+- @ref include/zos-macros.h
+- @ref include/zos-savstack.h
 - @ref include/zos-semaphore.h
 - @ref include/zos-sys-info.h
-
-*/
+- @ref include/zos-tls.h

--- a/mainpage/mainpage.dox
+++ b/mainpage/mainpage.dox
@@ -29,3 +29,30 @@ These are the main headers for ZOSLIB:
 - @ref include/zos-semaphore.h
 - @ref include/zos-sys-info.h
 - @ref include/zos-tls.h
+
+ZOSLIB also overrides the following LE headers:
+
+- @ref include/fcntl.h
+- @ref include/limits.h
+- @ref include/mntent.h
+- @ref include/netdb.h
+- @ref include/signal.h
+- @ref include/spawn.h
+- @ref include/stdio.h
+- @ref include/stdlib.h
+- @ref include/string.h
+- @ref include/time.h
+- @ref include/unistd.h
+- @ref include/utmpx.h
+- @ref include/sys/epoll.h
+- @ref include/sys/eventfd.h
+- @ref include/sys/file.h
+- @ref include/sys/fsstat.h
+- @ref include/sys/inotify.h
+- @ref include/sys/mount.h
+- @ref include/sys/param.h
+- @ref include/sys/socket.h
+- @ref include/sys/stat.h
+- @ref include/sys/sysmacros.h
+- @ref include/sys/time.h
+- @ref include/sys/types.h


### PR DESCRIPTION
* Also add links to the main headers in the zoslib API main page