### PR TITLE
implement aligned new and delete operators

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -45,8 +45,12 @@ shared_library("zoslib") {
     "src/zos-char-util.cc",
     "src/zos-getentropy.cc",
     "src/zos-io.cc",
+    "src/zos-locale.cc",
+    "src/zos-mkdtemp.c",
+    "src/zos-mount.c",
     "src/zos-semaphore.cc",
     "src/zos-spawn.cc",
+    "src/zos-string.c",
     "src/zos-sys-info.cc",
     "src/zos-tls.cc",
   ]

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -9,13 +9,16 @@
 config("zoslib_config") {
   include_dirs = [
     "include",
+    "include/c++/v1",
   ]
   # min arch14 is required for zos-getentropy.cc to use PRNO instruction.
   cflags = [
-    "-march=arch14",
-    "-mzos-target=zosv2r4",
+    "-faligned-allocation",
     "-fno-short-enums",
     "-fzos-le-char-mode=ascii",
+    "-m64",
+    "-march=arch14",
+    "-mzos-target=zosv2r4",
   ]
 }
 
@@ -37,6 +40,7 @@ shared_library("zoslib") {
     "include/zos-sys-info.h",
     "include/zos-tls.h",
     "src/zos.cc",
+    "src/zos-aligned-newdel.cc",
     "src/zos-bpx.cc",
     "src/zos-char-util.cc",
     "src/zos-getentropy.cc",

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -13,7 +13,6 @@ config("zoslib_config") {
   ]
   # min arch14 is required for zos-getentropy.cc to use PRNO instruction.
   cflags = [
-    "-faligned-allocation",
     "-fno-short-enums",
     "-fzos-le-char-mode=ascii",
     "-m64",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,6 @@ if(${CMAKE_C_COMPILER} MATCHES xlclang)
 else()
   # min arch14 is required for zos-getentropy.cc to use PRNO instruction.
   list(APPEND zoslib_cflags
-    -faligned-allocation
     -fgnu-keywords
     -fno-short-enums
     -fzos-le-char-mode=ascii

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,8 @@ endif()
 
 set(CMAKE_CXX_FLAGS_DEBUG "-g" CACHE STRING "" FORCE)
 set(CMAKE_CXX_FLAGS_RELEASE "-O3" CACHE STRING "" FORCE)
+set(CMAKE_EXE_LINKER_FLAGS "-m64" CACHE STRING "" FORCE)
+set(CMAKE_SHARED_LINKER_FLAGS "-m64" CACHE STRING "" FORCE)
 
 list(APPEND zoslib_defines
   _AE_BIMODAL=1
@@ -73,18 +75,21 @@ if(${CMAKE_C_COMPILER} MATCHES xlclang)
     -qtune=10
     -qarch=10
     -qasm
-    -qasmlib=sys1.maclib:sys1.modgen)
+    -qasmlib=sys1.maclib:sys1.modgen
+  )
 
   target_link_options(zoslib PUBLIC "-Wl,DLL")
 else()
   # min arch14 is required for zos-getentropy.cc to use PRNO instruction.
   list(APPEND zoslib_cflags
+    -faligned-allocation
     -fgnu-keywords
+    -fno-short-enums
+    -fzos-le-char-mode=ascii
     -m64
     -march=arch14
     -mzos-target=zosv2r4
-    -fno-short-enums
-    -fzos-le-char-mode=ascii)
+  )
 
   target_link_options(zoslib PUBLIC "--shared")
 endif()

--- a/include/c++/v1/new
+++ b/include/c++/v1/new
@@ -1,0 +1,33 @@
+///////////////////////////////////////////////////////////////////////////////
+// Licensed Materials - Property of IBM
+// ZOSLIB
+// (C) Copyright IBM Corp. 2025. All Rights Reserved.
+// US Government Users Restricted Rights - Use, duplication
+// or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+///////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+#include_next <new>
+
+#if defined(__clang__) && !defined(__ibmxl__) && defined(__cpp_aligned_new) && \
+    !_LIBCPP_HAS_ALIGNED_ALLOCATION
+
+#include "zos-macros.h"
+
+namespace std {
+  enum class align_val_t : std::size_t {};
+}
+
+__Z_EXPORT void* operator new(size_t size, std::align_val_t al, const std::nothrow_t&) _NOEXCEPT;
+__Z_EXPORT void* operator new[](size_t size, std::align_val_t al, const std::nothrow_t&) _NOEXCEPT;
+__Z_EXPORT void* operator new(std::size_t size, std::align_val_t al) _THROW_BAD_ALLOC;
+__Z_EXPORT void* operator new[](std::size_t size, std::align_val_t al) _THROW_BAD_ALLOC;
+
+__Z_EXPORT void operator delete(void* ptr, std::align_val_t al) _NOEXCEPT;
+__Z_EXPORT void operator delete(void* ptr, std::align_val_t al, const std::nothrow_t&) _NOEXCEPT;
+__Z_EXPORT void operator delete(void* ptr, size_t, std::align_val_t al) _NOEXCEPT;
+__Z_EXPORT void operator delete[](void* ptr, std::align_val_t al) _NOEXCEPT;
+__Z_EXPORT void operator delete[](void* ptr, std::align_val_t al, const std::nothrow_t&) _NOEXCEPT;
+__Z_EXPORT void operator delete[](void* ptr, size_t, std::align_val_t al) _NOEXCEPT;
+
+#endif

--- a/include/c++/v1/new
+++ b/include/c++/v1/new
@@ -9,8 +9,7 @@
 #pragma once
 #include_next <new>
 
-#if defined(__clang__) && !defined(__ibmxl__) && defined(__cpp_aligned_new) && \
-    !_LIBCPP_HAS_ALIGNED_ALLOCATION
+#if defined(__clang__) && !defined(__ibmxl__) && !_LIBCPP_HAS_ALIGNED_ALLOCATION
 
 #include "zos-macros.h"
 

--- a/include/c++/v1/new
+++ b/include/c++/v1/new
@@ -9,7 +9,8 @@
 #pragma once
 #include_next <new>
 
-#if defined(__clang__) && !defined(__ibmxl__) && !_LIBCPP_HAS_ALIGNED_ALLOCATION
+#if defined(__clang__) && !defined(__ibmxl__) && \
+    defined(ZOSLIB_ALIGNED_NEWDEL) && !_LIBCPP_HAS_ALIGNED_ALLOCATION
 
 #include "zos-macros.h"
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,7 @@
 ###############################################################################
 
 set(libsrc
+  zos-aligned-newdel.cc
   zos-bpx.cc
   zos-char-util.cc
   zos-getentropy.cc

--- a/src/zos-aligned-newdel.cc
+++ b/src/zos-aligned-newdel.cc
@@ -1,0 +1,106 @@
+///////////////////////////////////////////////////////////////////////////////
+// Licensed Materials - Property of IBM
+// ZOSLIB
+// (C) Copyright IBM Corp. 2025. All Rights Reserved.
+// US Government Users Restricted Rights - Use, duplication
+// or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+//
+// The code in this source file is based on
+// https://github.com/llvm/llvm-project/blob/main/libcxx/src/new.cpp
+// for the aligned new and delete.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+///////////////////////////////////////////////////////////////////////////////
+
+#if defined(__clang__) && !defined(__ibmxl__) && defined(__cpp_aligned_new)
+// Compiled with -faligned-allocation
+
+#include <new>
+
+// Defined in libcxx/include/__config
+#if !_LIBCPP_HAS_ALIGNED_ALLOCATION
+#include "zos-base.h"
+
+
+static void* operator_new_aligned_impl(std::size_t size, std::align_val_t al) {
+  if (size == 0)
+    size = 1;
+  if (static_cast<size_t>(al) < sizeof(void*))
+    al = std::align_val_t(sizeof(void*));
+
+  void* p;
+  while ((p =__aligned_malloc(size, static_cast<size_t>(al))) == nullptr) {
+    // If malloc fails and there is a new_handler, call it to try free up memory
+    std::new_handler nh = std::get_new_handler();
+    if (nh)
+      nh();
+    else
+      break;
+  }
+  return p;
+}
+
+__Z_EXPORT void* operator new(std::size_t size, std::align_val_t al) _THROW_BAD_ALLOC {
+  void *p = operator_new_aligned_impl(size, al);
+  if (p == nullptr)
+    std::__throw_bad_alloc();
+  return p;
+}
+
+__Z_EXPORT void* operator new(size_t size, std::align_val_t al, const std::nothrow_t&) _NOEXCEPT {
+#if !__EXCEPTIONS
+  return operator_new_aligned_impl(size, al);
+#else
+  void* p = nullptr;
+  try {
+    p = ::operator new(size, al);
+  } catch (...) {
+  }
+  return p;
+#endif
+}
+
+__Z_EXPORT void* operator new[](std::size_t size, std::align_val_t al) _THROW_BAD_ALLOC {
+  return ::operator new(size, al);
+}
+
+__Z_EXPORT void* operator new[](size_t size, std::align_val_t al, const std::nothrow_t&) _NOEXCEPT {
+#if !__EXCEPTIONS
+  return __aligned_malloc(size, static_cast<size_t>(al));
+#else
+  void* p = nullptr;
+  try {
+    p = ::operator new[](size, al);
+  } catch (...) {
+  }
+  return p;
+#endif
+}
+
+__Z_EXPORT void operator delete(void* ptr, std::align_val_t al) _NOEXCEPT {
+  __aligned_free(ptr);
+}
+
+__Z_EXPORT void operator delete(void* ptr, std::align_val_t al, const std::nothrow_t&) _NOEXCEPT {
+  ::operator delete(ptr, al);
+}
+
+__Z_EXPORT void operator delete(void* ptr, size_t, std::align_val_t al) _NOEXCEPT {
+  ::operator delete(ptr, al);
+}
+
+__Z_EXPORT void operator delete[](void* ptr, std::align_val_t al) _NOEXCEPT {
+  ::operator delete(ptr, al);
+}
+
+__Z_EXPORT void operator delete[](void* ptr, std::align_val_t al, const std::nothrow_t&) _NOEXCEPT {
+  ::operator delete[](ptr, al);
+}
+
+__Z_EXPORT void operator delete[](void* ptr, size_t, std::align_val_t al) _NOEXCEPT {
+  ::operator delete[](ptr, al);
+}
+
+#endif  // #if !_LIBCPP_HAS_ALIGNED_ALLOCATION
+#endif  // #if defined(__clang__) && !defined(__ibmxl__) && defined(__cpp_aligned_new)

--- a/src/zos-aligned-newdel.cc
+++ b/src/zos-aligned-newdel.cc
@@ -13,12 +13,13 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 ///////////////////////////////////////////////////////////////////////////////
 
-#if defined(__clang__) && !defined(__ibmxl__)
+#if defined(__clang__) && !defined(__ibmxl__) && \
+    defined(ZOSLIB_ALIGNED_NEWDEL) && !_LIBCPP_HAS_ALIGNED_ALLOCATION
+
+// _LIBCPP_HAS_ALIGNED_ALLOCATION is defined in libcxx/include/__config
 
 #include <new>
 
-// Defined in libcxx/include/__config
-#if !_LIBCPP_HAS_ALIGNED_ALLOCATION
 #include "zos-base.h"
 
 
@@ -101,5 +102,4 @@ __Z_EXPORT void operator delete[](void* ptr, size_t, std::align_val_t al) _NOEXC
   ::operator delete[](ptr, al);
 }
 
-#endif  // #if !_LIBCPP_HAS_ALIGNED_ALLOCATION
-#endif  // #if defined(__clang__) && !defined(__ibmxl__)
+#endif

--- a/src/zos-aligned-newdel.cc
+++ b/src/zos-aligned-newdel.cc
@@ -13,8 +13,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 ///////////////////////////////////////////////////////////////////////////////
 
-#if defined(__clang__) && !defined(__ibmxl__) && defined(__cpp_aligned_new)
-// Compiled with -faligned-allocation
+#if defined(__clang__) && !defined(__ibmxl__)
 
 #include <new>
 
@@ -103,4 +102,4 @@ __Z_EXPORT void operator delete[](void* ptr, size_t, std::align_val_t al) _NOEXC
 }
 
 #endif  // #if !_LIBCPP_HAS_ALIGNED_ALLOCATION
-#endif  // #if defined(__clang__) && !defined(__ibmxl__) && defined(__cpp_aligned_new)
+#endif  // #if defined(__clang__) && !defined(__ibmxl__)

--- a/src/zos-string.c
+++ b/src/zos-string.c
@@ -115,11 +115,11 @@ const char *sigabbrev_np(int signum) {
 size_t strnlen(const char *str, size_t maxlen) {
   char *op1 = (char *)str + maxlen;
   char *op2 = (char *)str;
-  asm volatile(" SRST %0,%1\n"
-               " jo *-4"
-               : "+r"(op1), "+r"(op2)
-               : __ZL_NR("",r0)(0)
-               :);
+  __asm volatile(" SRST %0,%1\n"
+                 " jo *-4"
+                 : "+r"(op1), "+r"(op2)
+                 : __ZL_NR("",r0)(0)
+                 :);
   return op1 - str;
 
 }

--- a/test/test-aligned-newdel.cc
+++ b/test/test-aligned-newdel.cc
@@ -6,7 +6,8 @@
 // or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
 ///////////////////////////////////////////////////////////////////////////////
 
-#ifdef __cpp_aligned_new
+#if defined(__clang__) && !defined(__ibmxl__) && defined(__cpp_aligned_new)
+// __cpp_aligned_new is defined with -faligned-allocation
 
 #include "zos.h"
 #include "gtest/gtest.h"
@@ -110,4 +111,4 @@ TEST(AlignedNewDel, TestAllocArr) {
 }
 
 }      // namespace
-#endif //  #ifdef __cpp_aligned_new
+#endif // __clang__ && !__ibmxl__

--- a/test/test-aligned-newdel.cc
+++ b/test/test-aligned-newdel.cc
@@ -33,7 +33,7 @@ TEST(AlignedNewDel, TestBadAllocArrHandler) {
   size_t alignment = 8;
   size_t maxmem = getPhysMemory();
   std::set_new_handler(handler);
-  auto ptr = new(std::align_val_t{alignment}, (std::nothrow)) int[maxmem];
+  auto ptr = new(std::align_val_t(alignment), (std::nothrow)) int[maxmem];
   ASSERT_EQ(bHandlerCalled, true);
   ASSERT_EQ(ptr, nullptr);
 }
@@ -44,7 +44,7 @@ TEST(AlignedNewDel, TestBadAllocArr) {
   bool gotex = false;
   try {
     size_t maxmem = getPhysMemory();
-    auto ptr = new(std::align_val_t{alignment}) int[maxmem];
+    auto ptr = new(std::align_val_t(alignment)) int[maxmem];
     // This is so compiler doesn't optimize out the above call:
     ASSERT_EQ(ptr, nullptr);
   } catch (const std::bad_alloc& e) {
@@ -57,56 +57,56 @@ TEST(AlignedNewDel, TestBadAllocArr) {
 TEST(AlignedNewDel, TestBadAllocArrNoThrow) {
   size_t alignment = 8;
   size_t maxmem = getPhysMemory();
-  auto ptr = new(std::align_val_t{alignment}, (std::nothrow)) int[maxmem];
+  auto ptr = new(std::align_val_t(alignment), (std::nothrow)) int[maxmem];
   ASSERT_EQ(ptr, nullptr);
 }
 
 TEST(AlignedNewDel, TestAlloc) {
   size_t alignment = sysconf(_SC_PAGESIZE);
-  auto ptr = new(std::align_val_t{alignment}) int;
+  auto ptr = new(std::align_val_t(alignment)) int;
   ASSERT_NE(ptr, nullptr);
   ASSERT_EQ(reinterpret_cast<size_t>(ptr) % alignment, 0);
-  ::operator delete(ptr, std::align_val_t{alignment});
+  ::operator delete(ptr, std::align_val_t(alignment));
 }
 
 TEST(AlignedNewDel, TestAllocNoThrow) {
   size_t alignment = sysconf(_SC_PAGESIZE);
-  auto ptr = new(std::align_val_t{alignment}, (std::nothrow)) int;
+  auto ptr = new(std::align_val_t(alignment), (std::nothrow)) int;
   ASSERT_NE(ptr, nullptr);
   ASSERT_EQ(reinterpret_cast<size_t>(ptr) % alignment, 0);
-  ::operator delete(ptr, std::align_val_t{alignment}, (std::nothrow));
+  ::operator delete(ptr, std::align_val_t(alignment), (std::nothrow));
 }
 
 TEST(AlignedNewDel, TestAllocArrNoThrow) {
   size_t alignment = sysconf(_SC_PAGESIZE);
-  auto ptr = new(std::align_val_t{alignment}, (std::nothrow)) int[123];
+  auto ptr = new(std::align_val_t(alignment), (std::nothrow)) int[123];
   ASSERT_NE(ptr, nullptr);
   ASSERT_EQ(reinterpret_cast<size_t>(ptr) % alignment, 0);
-  ::operator delete[](ptr, std::align_val_t{alignment}, (std::nothrow));
+  ::operator delete[](ptr, std::align_val_t(alignment), (std::nothrow));
 }
 
 TEST(AlignedNewDel, TestAllocArrNoThrowDelSize) {
   size_t alignment = sysconf(_SC_PAGESIZE);
-  auto ptr = new(std::align_val_t{alignment}, (std::nothrow)) int[123];
+  auto ptr = new(std::align_val_t(alignment), (std::nothrow)) int[123];
   ASSERT_NE(ptr, nullptr);
   ASSERT_EQ(reinterpret_cast<size_t>(ptr) % alignment, 0);
-  ::operator delete[](ptr, sizeof(int[123]), std::align_val_t{alignment});
+  ::operator delete[](ptr, sizeof(int[123]), std::align_val_t(alignment));
 }
 
 TEST(AlignedNewDel, TestAllocNoThrowDelSize) {
   size_t alignment = sysconf(_SC_PAGESIZE);
-  auto ptr = new(std::align_val_t{alignment}) int;
+  auto ptr = new(std::align_val_t(alignment)) int;
   ASSERT_NE(ptr, nullptr);
   ASSERT_EQ(reinterpret_cast<size_t>(ptr) % alignment, 0);
-  ::operator delete(ptr, sizeof(int), std::align_val_t{alignment});
+  ::operator delete(ptr, sizeof(int), std::align_val_t(alignment));
 }
 
 TEST(AlignedNewDel, TestAllocArr) {
   size_t alignment = sysconf(_SC_PAGESIZE);
-  auto ptr = new(std::align_val_t{alignment}) int[123];
+  auto ptr = new(std::align_val_t(alignment)) int[123];
   ASSERT_NE(ptr, nullptr);
   ASSERT_EQ(reinterpret_cast<size_t>(ptr) % alignment, 0);
-  ::operator delete[](ptr, std::align_val_t{alignment});
+  ::operator delete[](ptr, std::align_val_t(alignment));
 }
 
 }      // namespace

--- a/test/test-aligned-newdel.cc
+++ b/test/test-aligned-newdel.cc
@@ -1,0 +1,113 @@
+///////////////////////////////////////////////////////////////////////////////
+// Licensed Materials - Property of IBM
+// ZOSLIB
+// (C) Copyright IBM Corp. 2025. All Rights Reserved.
+// US Government Users Restricted Rights - Use, duplication
+// or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+///////////////////////////////////////////////////////////////////////////////
+
+#ifdef __cpp_aligned_new
+
+#include "zos.h"
+#include "gtest/gtest.h"
+
+#include <new>
+
+namespace {
+
+bool bHandlerCalled;
+
+size_t getPhysMemory() {
+  size_t pages = __get_num_frames();
+  size_t page_size = sysconf(_SC_PAGESIZE);
+  return pages * page_size;
+}
+
+void handler()
+{
+  std::set_new_handler(nullptr);
+  bHandlerCalled = true;
+}
+
+TEST(AlignedNewDel, TestBadAllocArrHandler) {
+  size_t alignment = 8;
+  size_t maxmem = getPhysMemory();
+  std::set_new_handler(handler);
+  auto ptr = new(std::align_val_t{alignment}, (std::nothrow)) int[maxmem];
+  ASSERT_EQ(bHandlerCalled, true);
+  ASSERT_EQ(ptr, nullptr);
+}
+
+#if __EXCEPTIONS
+TEST(AlignedNewDel, TestBadAllocArr) {
+  size_t alignment = 8;
+  bool gotex = false;
+  try {
+    size_t maxmem = getPhysMemory();
+    auto ptr = new(std::align_val_t{alignment}) int[maxmem];
+    // This is so compiler doesn't optimize out the above call:
+    ASSERT_EQ(ptr, nullptr);
+  } catch (const std::bad_alloc& e) {
+    gotex = true;
+  }
+  ASSERT_EQ(gotex, true);
+}
+#endif
+
+TEST(AlignedNewDel, TestBadAllocArrNoThrow) {
+  size_t alignment = 8;
+  size_t maxmem = getPhysMemory();
+  auto ptr = new(std::align_val_t{alignment}, (std::nothrow)) int[maxmem];
+  ASSERT_EQ(ptr, nullptr);
+}
+
+TEST(AlignedNewDel, TestAlloc) {
+  size_t alignment = sysconf(_SC_PAGESIZE);
+  auto ptr = new(std::align_val_t{alignment}) int;
+  ASSERT_NE(ptr, nullptr);
+  ASSERT_EQ(reinterpret_cast<size_t>(ptr) % alignment, 0);
+  ::operator delete(ptr, std::align_val_t{alignment});
+}
+
+TEST(AlignedNewDel, TestAllocNoThrow) {
+  size_t alignment = sysconf(_SC_PAGESIZE);
+  auto ptr = new(std::align_val_t{alignment}, (std::nothrow)) int;
+  ASSERT_NE(ptr, nullptr);
+  ASSERT_EQ(reinterpret_cast<size_t>(ptr) % alignment, 0);
+  ::operator delete(ptr, std::align_val_t{alignment}, (std::nothrow));
+}
+
+TEST(AlignedNewDel, TestAllocArrNoThrow) {
+  size_t alignment = sysconf(_SC_PAGESIZE);
+  auto ptr = new(std::align_val_t{alignment}, (std::nothrow)) int[123];
+  ASSERT_NE(ptr, nullptr);
+  ASSERT_EQ(reinterpret_cast<size_t>(ptr) % alignment, 0);
+  ::operator delete[](ptr, std::align_val_t{alignment}, (std::nothrow));
+}
+
+TEST(AlignedNewDel, TestAllocArrNoThrowDelSize) {
+  size_t alignment = sysconf(_SC_PAGESIZE);
+  auto ptr = new(std::align_val_t{alignment}, (std::nothrow)) int[123];
+  ASSERT_NE(ptr, nullptr);
+  ASSERT_EQ(reinterpret_cast<size_t>(ptr) % alignment, 0);
+  ::operator delete[](ptr, sizeof(int[123]), std::align_val_t{alignment});
+}
+
+TEST(AlignedNewDel, TestAllocNoThrowDelSize) {
+  size_t alignment = sysconf(_SC_PAGESIZE);
+  auto ptr = new(std::align_val_t{alignment}) int;
+  ASSERT_NE(ptr, nullptr);
+  ASSERT_EQ(reinterpret_cast<size_t>(ptr) % alignment, 0);
+  ::operator delete(ptr, sizeof(int), std::align_val_t{alignment});
+}
+
+TEST(AlignedNewDel, TestAllocArr) {
+  size_t alignment = sysconf(_SC_PAGESIZE);
+  auto ptr = new(std::align_val_t{alignment}) int[123];
+  ASSERT_NE(ptr, nullptr);
+  ASSERT_EQ(reinterpret_cast<size_t>(ptr) % alignment, 0);
+  ::operator delete[](ptr, std::align_val_t{alignment});
+}
+
+}      // namespace
+#endif //  #ifdef __cpp_aligned_new

--- a/test/test-aligned-newdel.cc
+++ b/test/test-aligned-newdel.cc
@@ -6,8 +6,11 @@
 // or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
 ///////////////////////////////////////////////////////////////////////////////
 
-#if defined(__clang__) && !defined(__ibmxl__) && defined(__cpp_aligned_new)
-// __cpp_aligned_new is defined with -faligned-allocation
+#if defined(__clang__) && !defined(__ibmxl__) && defined(__cpp_aligned_new) && \
+    defined(ZOSLIB_ALIGNED_NEWDEL) && !_LIBCPP_HAS_ALIGNED_ALLOCATION
+
+// __cpp_aligned_new is defined with -faligned-allocation which is required to
+// compile this test.
 
 #include "zos.h"
 #include "gtest/gtest.h"
@@ -111,4 +114,4 @@ TEST(AlignedNewDel, TestAllocArr) {
 }
 
 }      // namespace
-#endif // __clang__ && !__ibmxl__
+#endif

--- a/zoslib.gyp
+++ b/zoslib.gyp
@@ -37,7 +37,6 @@
           ],
         }, {
           'cflags': [
-            '-faligned-allocation',
             '-fgnu-keywords',
             '-fno-short-enums',
             '-fzos-le-char-mode=ascii',

--- a/zoslib.gyp
+++ b/zoslib.gyp
@@ -28,15 +28,35 @@
       ],
       'conditions': [
         [ '"<!(echo $CC)" == "xlclang"', {
-          'cflags': ['-q64', '-qascii', '-qexportall', '-Wno-missing-field-initializers', '-qasmlib=//\\\'SYS1.MACLIB\\\''],
-          'include_dirs': ['include'],
+          'cflags': [
+            '-q64',
+            '-qascii',
+            '-qexportall',
+            '-Wno-missing-field-initializers',
+            '-qasmlib=//\\\'SYS1.MACLIB\\\'',
+          ],
         }, {
-          'cflags': ['-fzos-le-char-mode=ascii', '-fgnu-keywords', '-fno-short-enums', '-mzos-target=zosv2r4'],
-          'include_dirs': ['include', 'include/c++/v1'],
+          'cflags': [
+            '-faligned-allocation',
+            '-fgnu-keywords',
+            '-fno-short-enums',
+            '-fzos-le-char-mode=ascii',
+            '-m64',
+            '-march=arch14',
+            '-mzos-target=zosv2r4',
+          ],
+          'ldflags': [
+            '-m64',
+          ],
         }],
+      ],
+      'include_dirs': [
+        'include',
+        'include/c++/v1',
       ],
       'sources': [
         'src/zos.cc',
+        'src/zos-aligned-newdel.cc',
         'src/zos-bpx.cc',
         'src/zos-char-util.cc',
         'src/zos-getentropy.cc',

--- a/zoslib.gyp
+++ b/zoslib.gyp
@@ -61,6 +61,8 @@
         'src/zos-char-util.cc',
         'src/zos-getentropy.cc',
         'src/zos-io.cc',
+        'src/zos-locale.cc',
+        'src/zos-mkdtemp.c',
         'src/zos-mount.c',
         'src/zos-semaphore.cc',
         'src/zos-spawn.cc',


### PR DESCRIPTION
To enable the aligned new and delete operators in this PR:
- add compiler option `-faligned-allocation` to your app, and if you rely on a standalone build of zoslib, then add that option also to CMakeLists.txt/zoslib.gyp/BUILD.gn - otherwise use of such operators results in error, e.g.:
```
    error: aligned deallocation function of type 'void (void *, enum std::align_val_t) noexcept' is not available on z/OS
       28 |   auto ptr = new(std::align_val_t{al}) int;
          |               ^
    note: if you supply your own aligned allocation functions, use -faligned-allocation to silence this diagnostic
```
- similarly, add the macro `ZOSLIB_ALIGNED_NEWDEL` to enable those operators
- add new source files to zoslib.gyp and BUILD.gn
- replace `asm` by `__asm` - otherwise `-std=c11` doesn't recognize asm
- pass `-m64` to linker flags