### PR TITLE
Update zos-signalfd.c

### DIFF
--- a/src/zos-signalfd.c
+++ b/src/zos-signalfd.c
@@ -12,6 +12,7 @@
 #include <stdlib.h>
 #include <fcntl.h>
 #include <sys/signalfd.h>
+#include <string.h>
 
 static int signal_pipe[2] = {-1, -1};
 


### PR DESCRIPTION
Fix build failure: 

zoslib build is failing with bellow error 

/u/zkafkaau/tmp/zoslibport/zoslib/src/zos-signalfd.c:21:3: error: call to undeclared library function 'memset' with type 'void *(void *, int, ]
   21 |   memset(&siginfo, 0, sizeof(struct signalfd_siginfo));
      |   ^
/u/zkafkaau/tmp/zoslibport/zoslib/src/zos-signalfd.c:21:3: note: include the header <string.h> or explicitly provide a declaration for 'memset'
1 error generated.

Including <stding.h> to fix the issue