### PR TITLE
define new __tcbtid()

### DIFF
--- a/include/zos-base.h
+++ b/include/zos-base.h
@@ -17,6 +17,7 @@
 #endif
 
 #include <_Nascii.h>
+#include <pthread.h>
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -123,25 +124,19 @@ __Z_EXPORT unsigned long long __registerProduct(const char *major_version,
                                                 const char *pid);
 
 /**
- * Get the Thread ID.
- * \return returns the current thread id
- */
-__Z_EXPORT int gettid();
+ * Get the integral Thread ID from the current TCB.
+ * \return returns unsigned int Thread ID from the current TCB.
+ *
+ * Address 540 is pointer to current TCB:
+ * https://www.ibm.com/docs/en/zos/3.1.0?topic=rqe-psa-information
+*/
+inline unsigned int __tcbtid() { return *(unsigned int *__ptr32)(540); }
 
 /**
- * Get the main Thread ID.
- * If a process is started with sh -c, main thread id is 0;
- * if started with bash -c, main thread id is 2;
- * if started directly from the shell, main thread id is 1.
- * \return returns the current thread id
+ * Get the integral Thread ID as low order 4 bytes of pthread_self().__
+ * \return returns unsigned int Thread ID as low order 4 bytes of pthread_self().__
  */
-__Z_EXPORT int __getMainThreadId();
-
-/**
- * Get the pthread_self() for the main thread.
- * \return returns the current pthread_self() for main thread
- */
-__Z_EXPORT pthread_t __getMainThreadSelf();
+inline unsigned int gettid() { return (unsigned int)(pthread_self().__ & 0x7fffffff); }
 
 /**
  * Print backtrace of stack to file descriptor.

--- a/src/zos.cc
+++ b/src/zos.cc
@@ -95,7 +95,6 @@ bool __is_backtrace_on_abort = true;
 bool __zoslib_terminated = false;
 bool __gMainTerminating = false;
 
-int __gMainThreadId = -1;
 pthread_t __gMainThreadSelf = {-1u};
 char __gArgsStr[PATH_MAX*2] = "";
 char __gChildInfo[32] = "";
@@ -207,8 +206,6 @@ extern "C" void __xfer_env(void) {
     ++start;
   }
 }
-
-extern "C" int gettid() { return (int)(pthread_self().__ & 0x7fffffff); }
 
 static void init_tf_parms_t(__tf_parms_t *parm, char *pu_name_buf, size_t len1,
                             char *entry_name_buf, size_t len2,
@@ -2479,7 +2476,6 @@ bool __zinit::isValidZOSLIBEnvar(std::string envar) {
 }
 
 __zinit::__zinit() {
-  __gMainThreadId = gettid();
   __gMainThreadSelf = pthread_self();
 
   update_memlogging(__get_instance(), nullptr);


### PR DESCRIPTION
Also change gettid() return type to unsigned int and inline it; and remove undefined thread-id functions and variable.