### PR TITLE
Aligned operator new and delete

### DIFF
--- a/src/zos.cc
+++ b/src/zos.cc
@@ -3128,6 +3128,7 @@ extern "C" void __aligned_free(void *ptr) {
 }
 
 // aligned new and delete operators
+// TODO: remove when z/OS gets aligned allocation in C++
 namespace std {
     enum class align_val_t : std::size_t {};
 }

--- a/src/zos.cc
+++ b/src/zos.cc
@@ -3127,6 +3127,31 @@ extern "C" void __aligned_free(void *ptr) {
 #endif
 }
 
+// aligned new and delete operators
+namespace std {
+    enum class align_val_t : std::size_t {};
+}
+
+void* operator new(std::size_t size, std::align_val_t align) {
+    std::size_t alignment = static_cast<std::size_t>(align);
+    void* ptr = __aligned_malloc(size, alignment);
+    if (!ptr) throw std::bad_alloc();
+    return ptr;
+}
+void operator delete(void* ptr, std::align_val_t) noexcept {
+    __aligned_free(ptr);
+}
+void* operator new[](std::size_t size, std::align_val_t align) {
+    std::size_t alignment = static_cast<std::size_t>(align);
+    void* ptr = __aligned_malloc(size, alignment);
+    if (!ptr) throw std::bad_alloc();
+    return ptr;
+}
+void operator delete[](void * ptr, std::align_val_t) noexcept {
+  __aligned_free(ptr);
+}
+// end: aligned new and delete operators
+
 // C Library overrides
 int __sysconf_orig(int ) asm("sysconf");
 


### PR DESCRIPTION
z/OS is by default missing aligned new and delete, needed for allocations that have to be more aligned than the default 8-byte alignment. Essentially added wrappers around zoslib's existing ``__aligned_malloc`` and ``__aligned_free``. 

If an application developer wants to use these functions and avoid build errors, they should build their project with the ``-faligned-allocation`` clang compiler flag