### PR TITLE
define __Z_EXPORT for zos-aligned-newdel.cc

### DIFF
--- a/src/alnewdel/zos-aligned-newdel.cc
+++ b/src/alnewdel/zos-aligned-newdel.cc
@@ -19,6 +19,10 @@
 #include <assert.h>
 #include <errno.h>
 
+#ifndef __Z_EXPORT
+#define __Z_EXPORT __attribute__((visibility("default")))
+#endif
+
 namespace {
 
 void *aligned_malloc(size_t size, size_t alignment) {


### PR DESCRIPTION
The new archive zoslib_alnewdel.a doesn't require any of zoslib's include headers/wrappers, including zos-macros.h that defines __Z_EXPORT. However, an error (macro not defined) wasn't detected because, in CMakeLists.txt, zoslib/include is added to all compilations, and in the case of src/alnewdel/zos-aligned-newdel.cc, the compiler's include/c++/v1/cstdlib includes stdlib.h from zoslib, which includes zos-macros.h, and so __Z_EXPORT is defined. And in cases where BUILD.gn or zoslib.gyp is used, the app also includes both zoslib/include and zoslib/include-wrappers/c++, so similarly there was no error.