### PR TITLE
Add __UNTAGGED_FILE_ENCODING environment variable

### DIFF
--- a/include/zos-base.h
+++ b/include/zos-base.h
@@ -460,6 +460,7 @@ __Z_EXPORT void __tb(void);
 
 __Z_EXPORT notagread_t __get_no_tag_read_behaviour();
 __Z_EXPORT int __get_no_tag_ignore_ccsid1047();
+__Z_EXPORT int __get_untagged_file_ccsid();
 
 #ifdef __cplusplus
 /**

--- a/man/zoslib.1
+++ b/man/zoslib.1
@@ -24,24 +24,46 @@ New files are created with encoding IBM-1047 and tagged IBM-1047.
 New files are created without translation and are tagged as BINARY.
 
 .TP
-.B __UNTAGGED_READ_MODE=AUTO
-(default) for handling of reading untagged files or files tagged with CCSID 1047 and txtflag turned off, up to 4k of datawill be read and checked, if it is found to be in CCSID 1047, data is converted
+.B __UNTAGGED_FILE_ENCODING
+(Recommended) Declares the encoding for untagged files. Takes precedence over __UNTAGGED_READ_MODE when both are set. Supports:
+.RS
+.IP \(bu 2
+.B DETECT
+\- (default) automatic detection, read up to 4k and check if CCSID 1047, then convert
+.IP \(bu 2
+.B IGNORE
+\- no conversion, treat untagged files as binary
+.IP \(bu 2
+.B WARN
+\- same as DETECT but issue a warning when conversion occurs
+.IP \(bu 2
+.B Numeric CCSID
+\- e.g., "1047", "819", "1208" - treat untagged files as that encoding
+.IP \(bu 2
+.B Encoding names
+\- e.g., "IBM-1047", "ISO8859-1", "UTF-8", "ASCII" - mapped to corresponding CCSID
+.RE
 
 .TP
-.B __UNTAGGED_READ_MODE=ASCII
-always convert data from CCSID 1047 to CCSID 819
-
-.TP
-.B __UNTAGGED_READ_MODE=NO
-changes the __UNTAGGED_READ_MODE behavior to ignore files tagged with CCSID 1047 and txtflag turned off
-
-.TP
-.B __UNTAGGED_READ_MODE=STRICT
-for no explicit conversion of data
-
-.TP
-.B __UNTAGGED_READ_MODE=WARN
-for same behavior as "AUTO" but issue a warning if conversion occurs
+.B __UNTAGGED_READ_MODE
+(Legacy/Compatibility) For handling of reading untagged files or files tagged with CCSID 1047 and txtflag turned off. When both __UNTAGGED_FILE_ENCODING and __UNTAGGED_READ_MODE are set, __UNTAGGED_FILE_ENCODING takes precedence. Supports:
+.RS
+.IP \(bu 2
+.B AUTO
+\- (default) automatic detection, same as DETECT
+.IP \(bu 2
+.B ASCII
+\- always convert data from CCSID 1047 to CCSID 819
+.IP \(bu 2
+.B NO
+\- ignore files tagged with CCSID 1047 and txtflag turned off
+.IP \(bu 2
+.B STRICT
+\- no explicit conversion of data, same as IGNORE
+.IP \(bu 2
+.B WARN
+\- same as AUTO but issue a warning if conversion occurs
+.RE
 
 .TP
 .B __MEMORY_USAGE_LOG_LEVEL
@@ -56,11 +78,35 @@ name of the log file associated with __MEMORY_USAGE_LOG_LEVEL, including 'stdout
 set to toggle debug ZOSLIB mode
 
 .SH EXAMPLES
-To set the __UNTAGGED_READ_MODE environment variable to STRICT and disable explicit conversion of data:
+To declare that untagged files should be treated as UTF-8:
+
+.B export __UNTAGGED_FILE_ENCODING=UTF-8
+
+This will cause ZOSLIB to treat all untagged files as UTF-8 (CCSID 1208) and perform appropriate conversion.
+
+To declare that untagged files should be treated as EBCDIC (CCSID 1047):
+
+.B export __UNTAGGED_FILE_ENCODING=1047
+
+This will cause ZOSLIB to treat all untagged files as CCSID 1047 and perform conversion to ASCII.
+
+To disable conversion of untagged files:
+
+.B export __UNTAGGED_FILE_ENCODING=IGNORE
+
+This will cause ZOSLIB to not perform any explicit conversion of data for untagged files.
+
+To enable automatic detection with warnings:
+
+.B export __UNTAGGED_FILE_ENCODING=WARN
+
+This will cause ZOSLIB to automatically detect encoding for untagged files and issue a warning when conversion occurs.
+
+To use the legacy mode (for backwards compatibility):
 
 .B export __UNTAGGED_READ_MODE=STRICT
 
-This will cause ZOSLIB to not perform any explicit conversion of data for untagged files or files tagged with CCSID 1047 and txtflag turned off.
+This will cause ZOSLIB to not perform any explicit conversion of data for untagged files or files tagged with CCSID 1047 and txtflag turned off. Note that __UNTAGGED_FILE_ENCODING takes precedence if both are set.
 
 To set the STDOUT CCSID to 819 (ASCII):
 

--- a/test/test-untagged-integration.cc
+++ b/test/test-untagged-integration.cc
@@ -1,0 +1,142 @@
+///////////////////////////////////////////////////////////////////////////////
+// Licensed Materials - Property of IBM
+// ZOSLIB
+// (C) Copyright IBM Corp. 2025. All Rights Reserved.
+// US Government Users Restricted Rights - Use, duplication
+// or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+///////////////////////////////////////////////////////////////////////////////
+
+#include "gtest/gtest.h"
+#include "zos-base.h"
+#include <stdlib.h>
+
+/**
+ * Integration tests to verify __UNTAGGED_FILE_ENCODING is properly
+ * integrated with existing zoslib behavior.
+ */
+
+class UntaggedIntegrationTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    // Clear environment variables before each test
+    unsetenv("__UNTAGGED_FILE_ENCODING");
+    unsetenv("__UNTAGGED_READ_MODE");
+    // Force re-initialization of settings
+    __update_envar_settings(NULL);
+  }
+
+  void TearDown() override {
+    // Clean up after each test
+    unsetenv("__UNTAGGED_FILE_ENCODING");
+    unsetenv("__UNTAGGED_READ_MODE");
+    __update_envar_settings(NULL);
+  }
+};
+
+// Test that new variable integrates with __get_no_tag_read_behaviour
+TEST_F(UntaggedIntegrationTest, NewVariableSetsLegacyBehavior) {
+  // DETECT should map to __NO_TAG_READ_DEFAULT
+  setenv("__UNTAGGED_FILE_ENCODING", "DETECT", 1);
+  __update_envar_settings("__UNTAGGED_READ_MODE");
+  EXPECT_EQ(__NO_TAG_READ_DEFAULT, __get_no_tag_read_behaviour());
+
+  // WARN should map to __NO_TAG_READ_DEFAULT_WITHWARNING
+  setenv("__UNTAGGED_FILE_ENCODING", "WARN", 1);
+  __update_envar_settings("__UNTAGGED_READ_MODE");
+  EXPECT_EQ(__NO_TAG_READ_DEFAULT_WITHWARNING, __get_no_tag_read_behaviour());
+
+  // IGNORE should map to __NO_TAG_READ_STRICT
+  setenv("__UNTAGGED_FILE_ENCODING", "IGNORE", 1);
+  __update_envar_settings("__UNTAGGED_READ_MODE");
+  EXPECT_EQ(__NO_TAG_READ_STRICT, __get_no_tag_read_behaviour());
+
+  // Explicit CCSID should map to __NO_TAG_READ_V6
+  setenv("__UNTAGGED_FILE_ENCODING", "1047", 1);
+  __update_envar_settings("__UNTAGGED_READ_MODE");
+  EXPECT_EQ(__NO_TAG_READ_V6, __get_no_tag_read_behaviour());
+}
+
+// Test that CCSID is stored correctly
+TEST_F(UntaggedIntegrationTest, CCSIDIsStored) {
+  setenv("__UNTAGGED_FILE_ENCODING", "1047", 1);
+  __update_envar_settings("__UNTAGGED_READ_MODE");
+  EXPECT_EQ(1047, __get_untagged_file_ccsid());
+
+  setenv("__UNTAGGED_FILE_ENCODING", "UTF-8", 1);
+  __update_envar_settings("__UNTAGGED_READ_MODE");
+  EXPECT_EQ(1208, __get_untagged_file_ccsid());
+
+  setenv("__UNTAGGED_FILE_ENCODING", "819", 1);
+  __update_envar_settings("__UNTAGGED_READ_MODE");
+  EXPECT_EQ(819, __get_untagged_file_ccsid());
+
+  // Semantic tokens should have CCSID 0
+  setenv("__UNTAGGED_FILE_ENCODING", "DETECT", 1);
+  __update_envar_settings("__UNTAGGED_READ_MODE");
+  EXPECT_EQ(0, __get_untagged_file_ccsid());
+}
+
+// Test precedence: new variable overrides legacy
+TEST_F(UntaggedIntegrationTest, NewVariableOverridesLegacy) {
+  setenv("__UNTAGGED_READ_MODE", "STRICT", 1);
+  setenv("__UNTAGGED_FILE_ENCODING", "1047", 1);
+  __update_envar_settings("__UNTAGGED_READ_MODE");
+
+  // New variable should take precedence, resulting in V6 mode (forced conversion)
+  EXPECT_EQ(__NO_TAG_READ_V6, __get_no_tag_read_behaviour());
+  EXPECT_EQ(1047, __get_untagged_file_ccsid());
+}
+
+// Test legacy variable still works when new variable not set
+TEST_F(UntaggedIntegrationTest, LegacyVariableStillWorks) {
+  setenv("__UNTAGGED_READ_MODE", "WARN", 1);
+  __update_envar_settings("__UNTAGGED_READ_MODE");
+  EXPECT_EQ(__NO_TAG_READ_DEFAULT_WITHWARNING, __get_no_tag_read_behaviour());
+
+  setenv("__UNTAGGED_READ_MODE", "STRICT", 1);
+  __update_envar_settings("__UNTAGGED_READ_MODE");
+  EXPECT_EQ(__NO_TAG_READ_STRICT, __get_no_tag_read_behaviour());
+
+  setenv("__UNTAGGED_READ_MODE", "ASCII", 1);
+  __update_envar_settings("__UNTAGGED_READ_MODE");
+  EXPECT_EQ(__NO_TAG_READ_V6, __get_no_tag_read_behaviour());
+  EXPECT_EQ(819, __get_untagged_file_ccsid());
+}
+
+// Test encoding name resolution
+TEST_F(UntaggedIntegrationTest, EncodingNameResolution) {
+  setenv("__UNTAGGED_FILE_ENCODING", "IBM-1047", 1);
+  __update_envar_settings("__UNTAGGED_READ_MODE");
+  EXPECT_EQ(__NO_TAG_READ_V6, __get_no_tag_read_behaviour());
+  EXPECT_EQ(1047, __get_untagged_file_ccsid());
+
+  setenv("__UNTAGGED_FILE_ENCODING", "ASCII", 1);
+  __update_envar_settings("__UNTAGGED_READ_MODE");
+  EXPECT_EQ(__NO_TAG_READ_V6, __get_no_tag_read_behaviour());
+  EXPECT_EQ(819, __get_untagged_file_ccsid());
+}
+
+// Test case insensitivity
+TEST_F(UntaggedIntegrationTest, CaseInsensitivity) {
+  setenv("__UNTAGGED_FILE_ENCODING", "detect", 1);
+  __update_envar_settings("__UNTAGGED_READ_MODE");
+  EXPECT_EQ(__NO_TAG_READ_DEFAULT, __get_no_tag_read_behaviour());
+
+  setenv("__UNTAGGED_FILE_ENCODING", "utf-8", 1);
+  __update_envar_settings("__UNTAGGED_READ_MODE");
+  EXPECT_EQ(__NO_TAG_READ_V6, __get_no_tag_read_behaviour());
+  EXPECT_EQ(1208, __get_untagged_file_ccsid());
+}
+
+// Test invalid values fallback to default
+TEST_F(UntaggedIntegrationTest, InvalidValuesFallback) {
+  setenv("__UNTAGGED_FILE_ENCODING", "INVALID", 1);
+  __update_envar_settings("__UNTAGGED_READ_MODE");
+  EXPECT_EQ(__NO_TAG_READ_DEFAULT, __get_no_tag_read_behaviour());
+  EXPECT_EQ(0, __get_untagged_file_ccsid());
+
+  unsetenv("__UNTAGGED_FILE_ENCODING");
+  setenv("__UNTAGGED_READ_MODE", "INVALID", 1);
+  __update_envar_settings("__UNTAGGED_READ_MODE");
+  EXPECT_EQ(__NO_TAG_READ_DEFAULT, __get_no_tag_read_behaviour());
+}


### PR DESCRIPTION
I am added a new environment variable because the existing  __UNTAGGED_READ_MODE is confusing to customers.  We will use __UNTAGGED_FILE_ENCODING

  Summary:
   - Add __UNTAGGED_FILE_ENCODING variable for encoding-first untagged file handling
   - Support semantic tokens: DETECT, IGNORE, WARN
   - Support numeric CCSIDs (e.g., 1047, 819, 1208)
   - Support encoding names via z/OS __toCcsid() (e.g., UTF-8, IBM-1047, ASCII)
   - New variable takes precedence over legacy __UNTAGGED_READ_MODE
   - Fully backwards compatible with existing __UNTAGGED_READ_MODE behavior

   Implementation:
   - Parser integrated into src/zos.cc (internal, no new library needed)
   - Added __get_untagged_file_ccsid() getter for CCSID retrieval
   - Updated __file_needs_conversion_init() to use explicit CCSID when specified
   - Comprehensive man page documentation with examples

   Testing:
   - Integration tests verify parsing, precedence, and behavior mapping
   - Tests confirm backwards compatibility with legacy variable

   Limitations:
   - Current conversion infrastructure supports EBCDIC (1047) ↔ ASCII (819)
   - Other CCSIDs parsed correctly but conversion limited until iconv() integration